### PR TITLE
add convenience script to startup dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,6 @@ Sourcegraph resource estimator
 ## Development Prerequisites
 
 - [Install Go](https://golang.org/doc/install), then:
-- Install `wasmserve`:
-
-```sh
-go get -u github.com/hajimehoshi/wasmserve
-```
-
 ### Optional prerequisites
 
 The project includes a [justfile](https://github.com/sourcegraph/infrastructure/blob/main/justfile) that includes simple
@@ -29,9 +23,7 @@ You can install `just` and the various commands it calls by either:
 ## Development
 
 ```sh
-cd resource-estimator/
-export GOROOT=$(go env GOROOT)
-wasmserve -allow-origin='*'
+./scripts/watch-wasm.sh # or "just watch | just dev"
 ```
 
 This will start serving on http://localhost:8080 the WASM bundle and recompiling code each time you reload the page (any errors compiling your changes will show up in this terminal).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Sourcegraph resource estimator
 ## Development Prerequisites
 
 - [Install Go](https://golang.org/doc/install), then:
+
 ### Optional prerequisites
 
 The project includes a [justfile](https://github.com/sourcegraph/infrastructure/blob/main/justfile) that includes simple

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sourcegraph/resource-estimator
 go 1.16
 
 require (
+	github.com/hajimehoshi/wasmserve v0.0.0-20210512070053-db8e7b58c3a0
 	github.com/hexops/vecty v0.6.0
 	github.com/microcosm-cc/bluemonday v1.0.2
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/hajimehoshi/wasmserve v0.0.0-20210512070053-db8e7b58c3a0 h1:WhqBqA/lLy/+rpmXEIaykkcT/pBKN2sgOjXbLJ8pE3M=
+github.com/hajimehoshi/wasmserve v0.0.0-20210512070053-db8e7b58c3a0/go.mod h1:DI8IeyYdAkNS/K9JvLFBab7cmOkvoLCvMS9U8hLP2tw=
 github.com/hexops/vecty v0.6.0 h1:iiHfDOLEJufGy/hfPGzOTPkZe6rCszElYmUSzRQqK1w=
 github.com/hexops/vecty v0.6.0/go.mod h1:hVOPHAhrkXTf/9fl31Bpn2QvkW2ZOUZ0I3b3cohwCpI=
 github.com/microcosm-cc/bluemonday v1.0.2 h1:5lPfLTTAvAbtS0VqT+94yOtFnGfUWYyx0+iToC3Os3s=

--- a/justfile
+++ b/justfile
@@ -16,6 +16,12 @@ check: check-dhall
 build-wasm:
     ./build.sh
 
+dev: watch
+
+watch: watch-wasm
+watch-wasm:
+    ./scripts/watch-wasm.sh
+
 prettier:
     yarn run prettier
 

--- a/scripts/watch-wasm.sh
+++ b/scripts/watch-wasm.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"/..
+set -euxo pipefail
+
+go get github.com/hajimehoshi/wasmserve
+
+GOROOT=$(go env GOROOT)
+export GOROOT
+
+wasmserve -allow-origin='*'

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,9 @@
+//go:build tools
+// +build tools
+
+package main
+
+import (
+	// Used to serve the WASM bundle while developing
+	_ "github.com/hajimehoshi/wasmserve"
+)


### PR DESCRIPTION
- lock wasmserve with tools.go
- add script to automatically fetch wasmserve and run it via `just dev`