### PR TITLE
ensure consistent replica count for indexed-search

### DIFF
--- a/internal/scaling/references.go
+++ b/internal/scaling/references.go
@@ -142,6 +142,12 @@ var References = []ServiceScale{
 	},
 }
 
+// pods list services which live in the same pod. This is used to ensure we
+// recommend the same number of replicas.
+var pods = map[string][]string{
+	"indexed-search": {"zoekt-webserver", "zoekt-indexserver"},
+}
+
 var defaults = map[string]map[string]ReferencePoint{
 	"kubernetes": {
 		"prometheus":     ReferencePoint{Replicas: 1, CPU: Resource{.5, .5}, MemoryGB: Resource{2, 2}},

--- a/internal/scaling/scaling.go
+++ b/internal/scaling/scaling.go
@@ -214,6 +214,22 @@ func (e *Estimate) Calculate() *Estimate {
 		e.DeploymentType = "docker-compose"
 	}
 
+	// Ensure we have the same replica counts for services that live in the
+	// same pod.
+	for _, pod := range pods {
+		maxReplicas := 0
+		for _, name := range pod {
+			if replicas := e.Services[name].Replicas; replicas > maxReplicas {
+				maxReplicas = replicas
+			}
+		}
+		for _, name := range pod {
+			v := e.Services[name]
+			v.Replicas = maxReplicas
+			e.Services[name] = v
+		}
+	}
+
 	var (
 		sumCPURequests, sumCPULimits, sumMemoryGBRequests, sumMemoryGBLimits float64
 		largestCPULimit, largestMemoryGBLimit                                float64


### PR DESCRIPTION
I got feedback from a customer that they used the resource estimator and
it gave back different replica counts for zoekt-indexserver and
zoekt-webserver. This confused him and sent him down a rabbithole which
wasted his time.

This adds an invariant which sets the replica count between the two to
always be the max between them.

Test Plan: Added a test which ensures replica counts are the same. It
failed before the code change.

Part of https://github.com/sourcegraph/sourcegraph/issues/37194