### PR TITLE
ci: use golangci-lint v1.46.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,9 +68,9 @@ jobs:
       - name: Install asdf tool versions and packages
         run: './ci/asdf-install.sh'
       - name: 'golangci-lint (.)'
-        uses: 'golangci/golangci-lint-action@v2.5.2'
+        uses: 'golangci/golangci-lint-action@v3'
         with:
-          version: v1.39.0
+          version: v1.46.2
           working-directory: '.'
   prettier:
     name: Prettier formatting

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -77,7 +77,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - nakedret
     - nolintlint
     - revive

--- a/ci/dhall/jobs/golangci-lint.dhall
+++ b/ci/dhall/jobs/golangci-lint.dhall
@@ -16,9 +16,9 @@ let MakeSteps
           ( λ(d : Text) →
               GitHubActions.Step::{
               , name = Some "golangci-lint (${d})"
-              , uses = Some "golangci/golangci-lint-action@v2.5.2"
+              , uses = Some "golangci/golangci-lint-action@v3"
               , `with` = Some
-                  (toMap { version = "v1.39.0", working-directory = d })
+                  (toMap { version = "v1.46.2", working-directory = d })
               }
           )
           dirs


### PR DESCRIPTION
CI is failing on my PRs, but locally everything is fine. Attempting to
upgrade the linter in hopes it resolves the issues.

Removed interfacer since it has been deprecated since v1.38.0.

Test Plan: CI