### PR TITLE
Update Go version from 1.16 to 1.18

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.16
+golang 1.18
 dhall 1.39.0
 shellcheck 0.7.1
 shfmt 3.2.1

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,27 @@
 module github.com/sourcegraph/resource-estimator
 
-go 1.16
+go 1.18
 
 require (
 	github.com/hajimehoshi/wasmserve v0.0.0-20210512070053-db8e7b58c3a0
 	github.com/hexops/autogold v1.3.0
 	github.com/hexops/vecty v0.6.0
 	github.com/microcosm-cc/bluemonday v1.0.2
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1
+)
+
+require (
+	github.com/google/go-cmp v0.5.4 // indirect
+	github.com/hexops/gotextdiff v1.0.3 // indirect
+	github.com/hexops/valast v1.4.0 // indirect
+	github.com/nightlyone/lockfile v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/shurcooL/go-goon v0.0.0-20210110234559-7585751d9a17 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	golang.org/x/mod v0.4.1 // indirect
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
+	golang.org/x/sys v0.0.0-20210218084038-e8e29180ff58 // indirect
+	golang.org/x/tools v0.1.0 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	mvdan.cc/gofumpt v0.1.0 // indirect
 )


### PR DESCRIPTION
Updating Go version to build the current estimator in production with the latest Go version before the rewrite is finalized. 