### PR TITLE
Update indexserver disk size calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# resource-estimator
+# Sourcegraph resource estimator
 
-Sourcegraph resource estimator
+Sourcegraph resource estimator helps predict and plan the required resource for your deployment.
+
+This tool ensures you provision appropriate resources to scale your instance.
 
 ## Development Prerequisites
 
@@ -39,6 +41,10 @@ This is the best option as you can see the page with full CSS styling.
 ### Developing without the docsite
 
 You can view the page without any CSS styling at http://localhost:8080
+
+### Golden test
+
+Run `go test -update` in the internal/scaling directory to update the tests
 
 ## Releasing
 

--- a/internal/scaling/scaling.go
+++ b/internal/scaling/scaling.go
@@ -185,7 +185,6 @@ type Estimate struct {
 	AverageRepositories int                       // Number of total repositories including monorepos: number repos + monorepos x 50
 	ContactSupport      bool                      // Contact support required
 	EngagedUsers        int                       // Number of users x engagement rate
-	IndexServerDiskSize int                       // Disk size of Indexserver: gitserver disk space x gitserver replicas count
 	Services            map[string]ReferencePoint // List of services output
 	UserRepoSumRatio    int                       // The ratio used to determine deployment size:  (user count + average repos count) / 1000
 
@@ -234,22 +233,6 @@ func (e *Estimate) Calculate() *Estimate {
 	}
 	if e.DeploymentType == "type" {
 		e.DeploymentType = "kubernetes"
-	}
-	// Get index server disk size
-	// Typically the gitserver disk size multipled by the number of gitserver shards
-	// formula: size of gitserver (size of all repos x 120%) x gitserver replicas
-	// ref: https://github.com/sourcegraph/deploy-sourcegraph/blob/v3.41.0/base/indexed-search/indexed-search.StatefulSet.yaml#L84
-	switch {
-	case e.UserRepoSumRatio < 5:
-		e.IndexServerDiskSize = e.TotalRepoSize * 120 / 100
-	case e.UserRepoSumRatio < 20:
-		e.IndexServerDiskSize = e.TotalRepoSize * 120 / 100 * 2
-	case e.UserRepoSumRatio < 30:
-		e.IndexServerDiskSize = e.TotalRepoSize * 120 / 100 * 3
-	case e.UserRepoSumRatio < int(UserRepoSumRatioRange.Max):
-		e.IndexServerDiskSize = e.TotalRepoSize * 120 / 100 * 4
-	default:
-		e.IndexServerDiskSize = e.TotalRepoSize * 120 / 100 * 5
 	}
 	// Ensure we have the same replica counts for services that live in the
 	// same pod.
@@ -430,8 +413,9 @@ func (e *Estimate) Result() []byte {
 	fmt.Fprintf(&buf, "| gitserver | %v | At least 20 percent more than the total size of all repositories. |\n", fmt.Sprint(float64(e.TotalRepoSize*120/100), "GBꜝ"))
 	fmt.Fprintf(&buf, "| minio | %v | The size of the largest LSIF index file. |\n", fmt.Sprint(e.LargestIndexSize, "GB"))
 	fmt.Fprintf(&buf, "| pgsql | %v | Two times the size of your current database is required for migration. |\n", fmt.Sprint(e.TotalRepoSize*2, "GB"))
-	fmt.Fprintf(&buf, "| indexed-search | %v | The disk size for gitserver multiplied by the number of gitserver replicas. |\n", fmt.Sprint(e.IndexServerDiskSize, "GBꜝ"))
-	fmt.Fprintf(&buf, "> ꜝ<small> This value represents the total disk space required for the associated service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>\n")
+	// indexed-search disk size = gitserver/2 ref: https://sourcegraph.slack.com/archives/C07KZF47K/p1656516881102679?thread_ts=1656436334.261969&cid=C07KZF47K
+	fmt.Fprintf(&buf, "| indexed-search | %v | Approximately the total disk size for gitserver divided by 2. |\n", fmt.Sprint(float64(e.TotalRepoSize*120/100/2), "GBꜝ"))
+	fmt.Fprintf(&buf, "> ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>\n")
 
 	fmt.Fprintf(&buf, "\n")
 

--- a/internal/scaling/scaling.go
+++ b/internal/scaling/scaling.go
@@ -408,13 +408,13 @@ func (e *Estimate) Result() []byte {
 	fmt.Fprintf(&buf, "\n")
 	fmt.Fprintf(&buf, "| Service | Size | Note |\n")
 	fmt.Fprintf(&buf, "|---------|:------------:|------|\n")
-	fmt.Fprintf(&buf, "| codeinsights-db | 200GB | Starts at default value as the value depends entirely on usage and the specific Insights that are being created by users. |\n")
-	fmt.Fprintf(&buf, "| codeintel-db | 200GB | Starts at default value as the value depends entirely on the size of indexes being uploaded. If Rockskip is enabled, 4 times the size of all repositories indexed by Rockskip is required. |\n")
-	fmt.Fprintf(&buf, "| gitserver | %v | At least 20 percent more than the total size of all repositories. |\n", fmt.Sprint(float64(e.TotalRepoSize*120/100), "GBꜝ"))
-	fmt.Fprintf(&buf, "| minio | %v | The size of the largest LSIF index file. |\n", fmt.Sprint(e.LargestIndexSize, "GB"))
-	fmt.Fprintf(&buf, "| pgsql | %v | Two times the size of your current database is required for migration. |\n", fmt.Sprint(e.TotalRepoSize*2, "GB"))
+	fmt.Fprintf(&buf, "| codeinsights-db | 200GB | Starts at default as the value depends entirely on usage and the specific Insights that are being created by users. |\n")
+	fmt.Fprintf(&buf, "| codeintel-db | 200GB | Starts at default as the value depends entirely on the size of indexes being uploaded. If Rockskip is enabled, 4 times the size of all repositories indexed by Rockskip is required. |\n")
+	fmt.Fprintf(&buf, "| gitserver | %v | ~ 20 percent more than the total size of all repositories. |\n", fmt.Sprint(float64(e.TotalRepoSize*120/100), "GBꜝ"))
+	fmt.Fprintf(&buf, "| minio | %v | ~ The size of the largest LSIF index file. |\n", fmt.Sprint(e.LargestIndexSize, "GB"))
+	fmt.Fprintf(&buf, "| pgsql | 200GB | Starts at default as the value grows depending on the number of active users and activity. |\n")
 	// indexed-search disk size = gitserver*2/3 ref: PR#17
-	fmt.Fprintf(&buf, "| indexed-search | %v | Approximately 3/4 of the total gitserver disk size. |\n", fmt.Sprint(float64(e.TotalRepoSize*120/100*3/4), "GBꜝ"))
+	fmt.Fprintf(&buf, "| indexed-search | %v | Approximately half of the total gitserver disk size. |\n", fmt.Sprint(float64(e.TotalRepoSize*120/100/2), "GBꜝ"))
 	fmt.Fprintf(&buf, "> ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>\n")
 
 	fmt.Fprintf(&buf, "\n")
@@ -422,10 +422,11 @@ func (e *Estimate) Result() []byte {
 	// Ephemeral Storage
 	fmt.Fprintf(&buf, "### Ephemeral storage\n")
 	fmt.Fprintf(&buf, "\n")
-	fmt.Fprintf(&buf, "| Service | Size | Note |\n")
+	fmt.Fprintf(&buf, "| Service | Limits | Note |\n")
 	fmt.Fprintf(&buf, "|---------|:------------:|------|\n")
-	fmt.Fprintf(&buf, "| searcher| %v | The size of all indexed repositories. |\n", fmt.Sprint(float64(e.TotalRepoSize*30/100), "GB"))
-	fmt.Fprintf(&buf, "| symbols | %v | At least 20 percent more than the size of your largest repository. Using an SSD is highly preferred if you are not indexing with Rockskip. |\n", fmt.Sprint(float64(e.LargestRepoSize*120/100), "GB"))
+	fmt.Fprintf(&buf, "| searcher| %v | ~ Total number of average repositories divided by 100. |\n", fmt.Sprint(float64(e.AverageRepositories/100), "GBꜝ"))
+	fmt.Fprintf(&buf, "| symbols | %v | ~ 20 percent more than the size of your largest repository. Using an SSD is highly preferred if you are not indexing with Rockskip. |\n", fmt.Sprint(float64(e.LargestRepoSize*120/100), "GBꜝ"))
+	fmt.Fprintf(&buf, "> ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>\n")
 
 	fmt.Fprintf(&buf, "\n")
 

--- a/internal/scaling/scaling.go
+++ b/internal/scaling/scaling.go
@@ -424,8 +424,8 @@ func (e *Estimate) Result() []byte {
 	fmt.Fprintf(&buf, "\n")
 	fmt.Fprintf(&buf, "| Service | Limits | Note |\n")
 	fmt.Fprintf(&buf, "|---------|:------------:|------|\n")
-	fmt.Fprintf(&buf, "| searcher| %v | ~ Total number of average repositories divided by 100. |\n", fmt.Sprint(float64(e.AverageRepositories/100), "GBꜝ"))
-	fmt.Fprintf(&buf, "| symbols | %v | ~ 20 percent more than the size of your largest repository. Using an SSD is highly preferred if you are not indexing with Rockskip. |\n", fmt.Sprint(float64(e.LargestRepoSize*120/100), "GBꜝ"))
+	fmt.Fprintf(&buf, "| searcher| %vGBꜝ | ~ Total number of average repositories divided by 100. |\n", fmt.Sprintf("%.2f", float64(e.AverageRepositories/100)))
+	fmt.Fprintf(&buf, "| symbols | %vGBꜝ | ~ 20 percent more than the size of your largest repository. Using an SSD is highly preferred if you are not indexing with Rockskip. |\n", fmt.Sprint(float64(e.LargestRepoSize*120/100)))
 	fmt.Fprintf(&buf, "> ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>\n")
 
 	fmt.Fprintf(&buf, "\n")

--- a/internal/scaling/scaling.go
+++ b/internal/scaling/scaling.go
@@ -413,8 +413,8 @@ func (e *Estimate) Result() []byte {
 	fmt.Fprintf(&buf, "| gitserver | %v | At least 20 percent more than the total size of all repositories. |\n", fmt.Sprint(float64(e.TotalRepoSize*120/100), "GBꜝ"))
 	fmt.Fprintf(&buf, "| minio | %v | The size of the largest LSIF index file. |\n", fmt.Sprint(e.LargestIndexSize, "GB"))
 	fmt.Fprintf(&buf, "| pgsql | %v | Two times the size of your current database is required for migration. |\n", fmt.Sprint(e.TotalRepoSize*2, "GB"))
-	// indexed-search disk size = gitserver/2 ref: https://sourcegraph.slack.com/archives/C07KZF47K/p1656516881102679?thread_ts=1656436334.261969&cid=C07KZF47K
-	fmt.Fprintf(&buf, "| indexed-search | %v | Approximately the total disk size for gitserver divided by 2. |\n", fmt.Sprint(float64(e.TotalRepoSize*120/100/2), "GBꜝ"))
+	// indexed-search disk size = gitserver*2/3 ref: PR#17
+	fmt.Fprintf(&buf, "| indexed-search | %v | Approximately 3/4 of the total gitserver disk size. |\n", fmt.Sprint(float64(e.TotalRepoSize*120/100*3/4), "GBꜝ"))
 	fmt.Fprintf(&buf, "> ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>\n")
 
 	fmt.Fprintf(&buf, "\n")

--- a/internal/scaling/testdata/TestEstimate/default.golden
+++ b/internal/scaling/testdata/TestEstimate/default.golden
@@ -39,8 +39,8 @@
 | gitserver | 36GBꜝ | At least 20 percent more than the total size of all repositories. |
 | minio | 1GB | The size of the largest LSIF index file. |
 | pgsql | 60GB | Two times the size of your current database is required for migration. |
-| indexed-search | 36GBꜝ | The disk size for gitserver multiplied by the number of gitserver replicas. |
-> ꜝ<small> This value represents the total disk space required for the associated service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
+| indexed-search | 18GBꜝ | Approximately the total disk size for gitserver divided by 2. |
+> ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
 
 ### Ephemeral storage
 

--- a/internal/scaling/testdata/TestEstimate/default.golden
+++ b/internal/scaling/testdata/TestEstimate/default.golden
@@ -39,7 +39,7 @@
 | gitserver | 36GBꜝ | At least 20 percent more than the total size of all repositories. |
 | minio | 1GB | The size of the largest LSIF index file. |
 | pgsql | 60GB | Two times the size of your current database is required for migration. |
-| indexed-search | 18GBꜝ | Approximately the total disk size for gitserver divided by 2. |
+| indexed-search | 27GBꜝ | Approximately 3/4 of the total gitserver disk size. |
 > ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
 
 ### Ephemeral storage

--- a/internal/scaling/testdata/TestEstimate/default.golden
+++ b/internal/scaling/testdata/TestEstimate/default.golden
@@ -34,19 +34,20 @@
 
 | Service | Size | Note |
 |---------|:------------:|------|
-| codeinsights-db | 200GB | Starts at default value as the value depends entirely on usage and the specific Insights that are being created by users. |
-| codeintel-db | 200GB | Starts at default value as the value depends entirely on the size of indexes being uploaded. If Rockskip is enabled, 4 times the size of all repositories indexed by Rockskip is required. |
-| gitserver | 36GBꜝ | At least 20 percent more than the total size of all repositories. |
-| minio | 1GB | The size of the largest LSIF index file. |
-| pgsql | 60GB | Two times the size of your current database is required for migration. |
-| indexed-search | 27GBꜝ | Approximately 3/4 of the total gitserver disk size. |
+| codeinsights-db | 200GB | Starts at default as the value depends entirely on usage and the specific Insights that are being created by users. |
+| codeintel-db | 200GB | Starts at default as the value depends entirely on the size of indexes being uploaded. If Rockskip is enabled, 4 times the size of all repositories indexed by Rockskip is required. |
+| gitserver | 36GBꜝ | ~ 20 percent more than the total size of all repositories. |
+| minio | 1GB | ~ The size of the largest LSIF index file. |
+| pgsql | 200GB | Starts at default as the value grows depending on the number of active users and activity. |
+| indexed-search | 18GBꜝ | Approximately half of the total gitserver disk size. |
 > ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
 
 ### Ephemeral storage
 
-| Service | Size | Note |
+| Service | Limits | Note |
 |---------|:------------:|------|
-| searcher| 9GB | The size of all indexed repositories. |
-| symbols | 2GB | At least 20 percent more than the size of your largest repository. Using an SSD is highly preferred if you are not indexing with Rockskip. |
+| searcher| 3.00GBꜝ | ~ Total number of average repositories divided by 100. |
+| symbols | 2GBꜝ | ~ 20 percent more than the size of your largest repository. Using an SSD is highly preferred if you are not indexing with Rockskip. |
+> ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
 
 `

--- a/internal/scaling/testdata/TestEstimate/monorepo.golden
+++ b/internal/scaling/testdata/TestEstimate/monorepo.golden
@@ -39,8 +39,8 @@
 | gitserver | 36GBꜝ | At least 20 percent more than the total size of all repositories. |
 | minio | 1GB | The size of the largest LSIF index file. |
 | pgsql | 60GB | Two times the size of your current database is required for migration. |
-| indexed-search | 36GBꜝ | The disk size for gitserver multiplied by the number of gitserver replicas. |
-> ꜝ<small> This value represents the total disk space required for the associated service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
+| indexed-search | 18GBꜝ | Approximately the total disk size for gitserver divided by 2. |
+> ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
 
 ### Ephemeral storage
 

--- a/internal/scaling/testdata/TestEstimate/monorepo.golden
+++ b/internal/scaling/testdata/TestEstimate/monorepo.golden
@@ -39,7 +39,7 @@
 | gitserver | 36GBꜝ | At least 20 percent more than the total size of all repositories. |
 | minio | 1GB | The size of the largest LSIF index file. |
 | pgsql | 60GB | Two times the size of your current database is required for migration. |
-| indexed-search | 18GBꜝ | Approximately the total disk size for gitserver divided by 2. |
+| indexed-search | 27GBꜝ | Approximately 3/4 of the total gitserver disk size. |
 > ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
 
 ### Ephemeral storage

--- a/internal/scaling/testdata/TestEstimate/monorepo.golden
+++ b/internal/scaling/testdata/TestEstimate/monorepo.golden
@@ -34,19 +34,20 @@
 
 | Service | Size | Note |
 |---------|:------------:|------|
-| codeinsights-db | 200GB | Starts at default value as the value depends entirely on usage and the specific Insights that are being created by users. |
-| codeintel-db | 200GB | Starts at default value as the value depends entirely on the size of indexes being uploaded. If Rockskip is enabled, 4 times the size of all repositories indexed by Rockskip is required. |
-| gitserver | 36GBꜝ | At least 20 percent more than the total size of all repositories. |
-| minio | 1GB | The size of the largest LSIF index file. |
-| pgsql | 60GB | Two times the size of your current database is required for migration. |
-| indexed-search | 27GBꜝ | Approximately 3/4 of the total gitserver disk size. |
+| codeinsights-db | 200GB | Starts at default as the value depends entirely on usage and the specific Insights that are being created by users. |
+| codeintel-db | 200GB | Starts at default as the value depends entirely on the size of indexes being uploaded. If Rockskip is enabled, 4 times the size of all repositories indexed by Rockskip is required. |
+| gitserver | 36GBꜝ | ~ 20 percent more than the total size of all repositories. |
+| minio | 1GB | ~ The size of the largest LSIF index file. |
+| pgsql | 200GB | Starts at default as the value grows depending on the number of active users and activity. |
+| indexed-search | 18GBꜝ | Approximately half of the total gitserver disk size. |
 > ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
 
 ### Ephemeral storage
 
-| Service | Size | Note |
+| Service | Limits | Note |
 |---------|:------------:|------|
-| searcher| 9GB | The size of all indexed repositories. |
-| symbols | 2GB | At least 20 percent more than the size of your largest repository. Using an SSD is highly preferred if you are not indexing with Rockskip. |
+| searcher| 0.00GBꜝ | ~ Total number of average repositories divided by 100. |
+| symbols | 2GBꜝ | ~ 20 percent more than the size of your largest repository. Using an SSD is highly preferred if you are not indexing with Rockskip. |
+> ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
 
 `


### PR DESCRIPTION
As discussed with @keegancsmith [here](https://sourcegraph.slack.com/archives/C07KZF47K/p1656514667632159?thread_ts=1656436334.261969&cid=C07KZF47K), the indexserver disk no longer requires the amount of `gitserver * gitserver replicas` as stated in  our [deployment yaml file](https://sourcegraph.com/github.com/sourcegraph/deploy-sourcegraph/-/blob/base/indexed-search/indexed-search.StatefulSet.yaml?L83-84) for indexserver  . Based on the data we have gathered [here](https://docs.google.com/spreadsheets/d/1N7X_OXDwKk0QSR2Ghbj7ZhjVrQXcMNj-yC8mF1amBi4/edit#gid=609023588) (not including utiliziation rate), it looks like we have been using the average disk size is ~gitserver disk/2. 

Utilization rate for cse-k8s instance where 200GB of disk spaces are assigned to both gitserver and indexserver:
Gitserver usage~25GB
![image](https://user-images.githubusercontent.com/68532117/176492666-2bc02dd9-eb7c-4a80-8632-400ab570e593.png)
indexed-search usage ~19GB
![image](https://user-images.githubusercontent.com/68532117/176492772-17e3358c-fc56-40d2-9102-4fcdf5de732c.png)
 indexed-search-indexer
![image](https://user-images.githubusercontent.com/68532117/176492971-a8984916-8b36-4c8b-8db9-0a9ec5ed5810.png)

Dogfood
Gitserver usage ~3Ti
![image](https://user-images.githubusercontent.com/68532117/176493813-5387c6de-ba3f-45eb-a547-ecf330f246a3.png)
indexed-search usage ~1.9Ti
![image](https://user-images.githubusercontent.com/68532117/176493914-b8f3a821-f87d-4aa0-8a7a-20eb7e056f0d.png)
 indexed-search-indexer
![image](https://user-images.githubusercontent.com/68532117/176494142-ff6d6141-1e0b-4fc8-ad2e-00857746ab82.png)


Based on this, it'd be safer to assume the disk size for indexserver is roughly around 1/2 - 3/4 of gitserver disksize  

Test is passing:
```
resource-estimator/internal/scaling on  bee/disk [!] via 🐹 v1.18.3 took 2s
❯ go test
PASS
ok  	github.com/sourcegraph/resource-estimator/internal/scaling	0.249s
```