### PR TITLE
new feature: export result as Helm / docker-compose override files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+internal/scaling/scaling.go
 *.wasm
 # Binaries for programs and plugins
 *.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-internal/scaling/scaling.go
 *.wasm
 # Binaries for programs and plugins
 *.exe

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/google/go-cmp v0.5.4 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/hexops/valast v1.4.0 // indirect
@@ -23,5 +24,6 @@ require (
 	golang.org/x/sys v0.0.0-20210218084038-e8e29180ff58 // indirect
 	golang.org/x/tools v0.1.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	mvdan.cc/gofumpt v0.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/hajimehoshi/wasmserve v0.0.0-20220407032727-829ff31b29cd h1:ZPD+Q72UuYGFXRN7jNrKmpba+h0JumEYU+j4SyW8bRE=
@@ -61,9 +63,12 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 mvdan.cc/gofumpt v0.0.0-20210107193838-d24d34e18d44/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=
 mvdan.cc/gofumpt v0.1.0 h1:hsVv+Y9UsZ/mFZTxJZuHVI6shSQCtzZ11h1JEFPAZLw=
 mvdan.cc/gofumpt v0.1.0/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=

--- a/internal/scaling/references.go
+++ b/internal/scaling/references.go
@@ -8,7 +8,9 @@ var References = []ServiceScale{
 	// Add 2000 users to user count if code-insight is enabled
 	{
 		ServiceName:       "frontend",
+		ServiceLabel:      "sourcegraph-frontend",
 		DockerServiceName: "sourcegraph-frontend-0",
+		PodName:           "frontend",
 		ScalingFactor:     ByEngagedUsers, // UsersRange = {5, 10000}
 		ReferencePoints: []Service{
 			{Replicas: 5, Resources: Resources{Requests: Resource{CPU: 2, MEM: 8}, Limits: Resource{CPU: 4, MEM: 16}}, Value: UsersRange.Max}, // estimate
@@ -22,7 +24,9 @@ var References = []ServiceScale{
 	// Gitserver scales based on the total size of all repoes and number of average repositories.
 	{
 		ServiceName:       "gitserver",
+		ServiceLabel:      "gitserver",
 		DockerServiceName: "gitserver-0",
+		PodName:           "gitserver",
 		ScalingFactor:     ByUserRepoSumRatio,
 		ReferencePoints: []Service{
 			{Replicas: 5, Resources: Resources{Requests: Resource{CPU: 16, MEM: 32}, Limits: Resource{CPU: 16, MEM: 32}}, Value: UserRepoSumRatioRange.Max}, // estimate
@@ -39,7 +43,9 @@ var References = []ServiceScale{
 
 	{
 		ServiceName:       "minio",
+		ServiceLabel:      "minio",
 		DockerServiceName: "minio",
+		PodName:           "minio",
 		ScalingFactor:     ByLargestIndexSize,
 		ReferencePoints: []Service{
 			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: .5}, Limits: Resource{CPU: 1, MEM: .5}}, Storage: LargestIndexSizeRange.Max, Value: LargestIndexSizeRange.Max}, // calculation
@@ -50,7 +56,9 @@ var References = []ServiceScale{
 	// Memory usage depends on the number of active users and service-connections
 	{
 		ServiceName:       "pgsql",
+		ServiceLabel:      "pgsql",
 		DockerServiceName: "pgsql",
+		PodName:           "pgsql",
 		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 7, MEM: 32}, Limits: Resource{CPU: 7, MEM: 32}}, Value: AverageRepositoriesRange.Max}, // existing deployment: dogfood
@@ -66,7 +74,9 @@ var References = []ServiceScale{
 	// calculation: ~2 times of the size of the largest index
 	{
 		ServiceName:       "preciseCodeIntel",
+		ServiceLabel:      "precise-code-intel-worker",
 		DockerServiceName: "precise-code-intel-worker",
+		PodName:           "precise-code-intel",
 		ScalingFactor:     ByLargestIndexSize,
 		ReferencePoints: []Service{
 			{Replicas: 4, Resources: Resources{Requests: Resource{CPU: 2, MEM: 25}, Limits: Resource{CPU: 4, MEM: 50}}, Value: LargestIndexSizeRange.Max}, // calculation
@@ -85,7 +95,9 @@ var References = []ServiceScale{
 	// Searcher replicas scale based the number of concurrent unidexed queries & number concurrent of structural searches
 	{
 		ServiceName:       "searcher",
+		ServiceLabel:      "searcher",
 		DockerServiceName: "searcher-0",
+		PodName:           "searcher",
 		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Replicas: 4, Value: AverageRepositoriesRange.Max}, // existing deployment: dogfood
@@ -96,7 +108,9 @@ var References = []ServiceScale{
 	// Memory scales based on the size of repositories (i.e. when large monorepos are in the picture).
 	{
 		ServiceName:       "searcher",
+		ServiceLabel:      "searcher",
 		DockerServiceName: "searcher-0",
+		PodName:           "searcher",
 		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Resources: Resources{Requests: Resource{CPU: 3, MEM: 4, EPH: 440}, Limits: Resource{CPU: 6, MEM: 8, EPH: 480}}, Value: AverageRepositoriesRange.Max}, // estimate. eph based on dogfood
@@ -110,7 +124,9 @@ var References = []ServiceScale{
 	// based on the size of repositories (i.e. when large monorepos are in the picture).
 	{
 		ServiceName:       "symbols",
+		ServiceLabel:      "symbols",
 		DockerServiceName: "symbols-0",
+		PodName:           "symbols",
 		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Replicas: 4, Value: AverageRepositoriesRange.Max}, // estimate
@@ -121,7 +137,9 @@ var References = []ServiceScale{
 	},
 	{
 		ServiceName:       "symbols",
+		ServiceLabel:      "symbols",
 		DockerServiceName: "symbols-0",
+		PodName:           "symbols",
 		ScalingFactor:     ByLargeMonorepos,
 		ReferencePoints: []Service{
 			{Resources: Resources{Requests: Resource{CPU: 2, MEM: 8}, Limits: Resource{CPU: 4, MEM: 16}}, Value: LargeMonoreposRange.Max},  // estimate
@@ -132,7 +150,9 @@ var References = []ServiceScale{
 	},
 	{
 		ServiceName:       "symbols",
+		ServiceLabel:      "symbols",
 		DockerServiceName: "symbols-0",
+		PodName:           "symbols",
 		ScalingFactor:     ByLargestRepoSize,
 		ReferencePoints: []Service{
 			{Resources: Resources{Requests: Resource{EPH: 5900}, Limits: Resource{EPH: 6000}}, Value: LargestRepoSizeRange.Max}, // calculation
@@ -152,7 +172,9 @@ var References = []ServiceScale{
 	// syntect-server should normally kill such processes and restart them if that happens.
 	{
 		ServiceName:       "syntectServer",
+		ServiceLabel:      "syntect-server",
 		DockerServiceName: "syntect-server",
+		PodName:           "syntect-server",
 		ScalingFactor:     ByEngagedUsers,
 		ReferencePoints: []Service{
 			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 2, MEM: 6}, Limits: Resource{CPU: 8, MEM: 12}}, Value: UsersRange.Max}, // estimate
@@ -164,7 +186,9 @@ var References = []ServiceScale{
 	// worker is used by different services, and mostly scale based on the number of average repositories to execute jobs
 	{
 		ServiceName:       "worker",
+		ServiceLabel:      "worker",
 		DockerServiceName: "worker",
+		PodName:           "worker",
 		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 2, MEM: 8}, Limits: Resource{CPU: 4, MEM: 16}}, Value: AverageRepositoriesRange.Max}, // estimate
@@ -176,7 +200,9 @@ var References = []ServiceScale{
 	// zoekt-indexserver memory usage scales based on whether it must index large monorepos
 	{
 		ServiceName:       "indexedSearch",
+		ServiceLabel:      "zoekt-indexserver",
 		DockerServiceName: "zoekt-indexserver-0",
+		PodName:           "indexed-search",
 		ScalingFactor:     ByLargeMonorepos,
 		ReferencePoints: []Service{
 			{Resources: Resources{Requests: Resource{MEM: 8}, Limits: Resource{MEM: 16}}, Value: LargeMonoreposRange.Max}, // estimate
@@ -188,7 +214,9 @@ var References = []ServiceScale{
 	// Set replica number to 0 as it will be synced with the replica number for webserver
 	{
 		ServiceName:       "indexedSearch",
+		ServiceLabel:      "zoekt-indexserver",
 		DockerServiceName: "zoekt-indexserver-0",
+		PodName:           "indexed-search",
 		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Replicas: 4, Resources: Resources{Requests: Resource{CPU: 4}, Limits: Resource{CPU: 8}}, Value: AverageRepositoriesRange.Max}, // estimate: 4 replics to serve 50k repos so 8CPU limit per replica should be enough
@@ -204,6 +232,8 @@ var References = []ServiceScale{
 	{
 		ServiceName:       "indexedSearchIndexer",
 		DockerServiceName: "zoekt-webserver-0",
+		ServiceLabel:      "zoekt-webserver",
+		PodName:           "indexed-search",
 		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Replicas: 4, Resources: Resources{Requests: Resource{MEM: 25}, Limits: Resource{MEM: 50}}, Value: AverageRepositoriesRange.Max}, // existing deployment: dogfood
@@ -217,6 +247,8 @@ var References = []ServiceScale{
 	{
 		ServiceName:       "indexedSearchIndexer",
 		DockerServiceName: "zoekt-webserver-0",
+		ServiceLabel:      "zoekt-webserver",
+		PodName:           "indexed-search",
 		ScalingFactor:     ByEngagedUsers,
 		ReferencePoints: []Service{
 			{Resources: Resources{Requests: Resource{CPU: 8}, Limits: Resource{CPU: 16}}, Value: UsersRange.Max}, // estimate

--- a/internal/scaling/references.go
+++ b/internal/scaling/references.go
@@ -9,12 +9,12 @@ var References = []ServiceScale{
 	{
 		ServiceName:   "frontend",
 		ScalingFactor: ByEngagedUsers, // UsersRange = {5, 10000}
-		ReferencePoints: []ReferencePoint{
-			{Replicas: 5, CPU: Resource{2, 4}, MemoryGB: Resource{8, 16}, Value: UsersRange.Max}, // estimate
-			{Replicas: 3, CPU: Resource{4, 8}, MemoryGB: Resource{8, 16}, Value: 5000},           // estimate
-			{Replicas: 3, CPU: Resource{2, 4}, MemoryGB: Resource{4, 8}, Value: 2100},            // existing deployment: #4
-			{Replicas: 2, CPU: Resource{2, 4}, MemoryGB: Resource{4, 8}, Value: 2050},            // existing deployment: #45
-			{Replicas: 2, CPU: Resource{2, 2}, MemoryGB: Resource{2, 4}, Value: UsersRange.Min},  // default for instance with <2000 users without code-insight
+		ReferencePoints: []Service{
+			{Replicas: 5, Resources: Resources{Requests: Resource{CPU: 2, MEM: 8}, Limits: Resource{CPU: 4, MEM: 16}}, Value: UsersRange.Max}, // estimate
+			{Replicas: 3, Resources: Resources{Requests: Resource{CPU: 4, MEM: 8}, Limits: Resource{CPU: 8, MEM: 16}}, Value: 5000},           // estimate
+			{Replicas: 3, Resources: Resources{Requests: Resource{CPU: 2, MEM: 4}, Limits: Resource{CPU: 4, MEM: 8}}, Value: 2100},            // existing deployment: #4
+			{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 2, MEM: 4}, Limits: Resource{CPU: 4, MEM: 8}}, Value: 2050},            // existing deployment: #45
+			{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 2, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}, Value: UsersRange.Min},  // default for instance with <2000 users without code-insight
 		},
 	},
 
@@ -22,16 +22,16 @@ var References = []ServiceScale{
 	{
 		ServiceName:   "gitserver",
 		ScalingFactor: ByUserRepoSumRatio,
-		ReferencePoints: []ReferencePoint{
-			{Replicas: 5, CPU: Resource{16, 16}, MemoryGB: Resource{32, 32}, Value: UserRepoSumRatioRange.Max}, // estimate
-			{Replicas: 4, CPU: Resource{16, 16}, MemoryGB: Resource{32, 32}, Value: 150},                       // estimate
-			{Replicas: 4, CPU: Resource{8, 8}, MemoryGB: Resource{16, 16}, Value: 50},                          // existing deployment: dogfood
-			{Replicas: 3, CPU: Resource{8, 8}, MemoryGB: Resource{32, 32}, Value: 30},                          // estimate
-			{Replicas: 3, CPU: Resource{8, 8}, MemoryGB: Resource{16, 16}, Value: 20},                          // estimate
-			{Replicas: 2, CPU: Resource{8, 8}, MemoryGB: Resource{32, 32}, Value: 10},                          // estimate
-			{Replicas: 2, CPU: Resource{8, 8}, MemoryGB: Resource{16, 16}, Value: 5},                           // estimate
-			{Replicas: 1, CPU: Resource{8, 8}, MemoryGB: Resource{16, 16}, Value: 2},                           // estimate
-			{Replicas: 1, CPU: Resource{4, 4}, MemoryGB: Resource{8, 8}, Value: UserRepoSumRatioRange.Min},     // default for instance with <4000 repos
+		ReferencePoints: []Service{
+			{Replicas: 5, Resources: Resources{Requests: Resource{CPU: 16, MEM: 32}, Limits: Resource{CPU: 16, MEM: 32}}, Value: UserRepoSumRatioRange.Max}, // estimate
+			{Replicas: 4, Resources: Resources{Requests: Resource{CPU: 16, MEM: 32}, Limits: Resource{CPU: 16, MEM: 32}}, Value: 150},                       // estimate
+			{Replicas: 4, Resources: Resources{Requests: Resource{CPU: 8, MEM: 16}, Limits: Resource{CPU: 8, MEM: 16}}, Value: 50},                          // existing deployment: dogfood
+			{Replicas: 3, Resources: Resources{Requests: Resource{CPU: 8, MEM: 32}, Limits: Resource{CPU: 8, MEM: 32}}, Value: 30},                          // estimate
+			{Replicas: 3, Resources: Resources{Requests: Resource{CPU: 8, MEM: 16}, Limits: Resource{CPU: 8, MEM: 16}}, Value: 20},                          // estimate
+			{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 8, MEM: 32}, Limits: Resource{CPU: 8, MEM: 32}}, Value: 10},                          // estimate
+			{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 8, MEM: 16}, Limits: Resource{CPU: 8, MEM: 16}}, Value: 5},                           // estimate
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 8, MEM: 16}, Limits: Resource{CPU: 8, MEM: 16}}, Value: 2},                           // estimate
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 8}, Limits: Resource{CPU: 4, MEM: 8}}, Value: UserRepoSumRatioRange.Min},     // default for instance with <4000 repos
 		},
 	},
 
@@ -39,11 +39,11 @@ var References = []ServiceScale{
 	{
 		ServiceName:   "pgsql",
 		ScalingFactor: ByAverageRepositories,
-		ReferencePoints: []ReferencePoint{
-			{Replicas: 1, CPU: Resource{7, 7}, MemoryGB: Resource{32, 32}, Value: AverageRepositoriesRange.Max}, // existing deployment: dogfood
-			{Replicas: 1, CPU: Resource{4, 4}, MemoryGB: Resource{16, 16}, Value: 25000},                        // existing deployment: #4
-			{Replicas: 1, CPU: Resource{4, 4}, MemoryGB: Resource{8, 8}, Value: 4000},                           // existing deployment: #43
-			{Replicas: 1, CPU: Resource{4, 4}, MemoryGB: Resource{4, 4}, Value: AverageRepositoriesRange.Min},   // bare minimum
+		ReferencePoints: []Service{
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 7, MEM: 32}, Limits: Resource{CPU: 7, MEM: 32}}, Value: AverageRepositoriesRange.Max}, // existing deployment: dogfood
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 16}, Limits: Resource{CPU: 4, MEM: 16}}, Value: 25000},                        // existing deployment: #4
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 8}, Limits: Resource{CPU: 4, MEM: 8}}, Value: 4000},                           // existing deployment: #43
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 4}, Limits: Resource{CPU: 4, MEM: 4}}, Value: AverageRepositoriesRange.Min},   // bare minimum
 		},
 	},
 
@@ -54,16 +54,16 @@ var References = []ServiceScale{
 	{
 		ServiceName:   "precise-code-intel",
 		ScalingFactor: ByLargestIndexSize,
-		ReferencePoints: []ReferencePoint{
-			{Replicas: 4, CPU: Resource{4, 4}, MemoryGB: Resource{25, 50}, Value: LargestIndexSizeRange.Max}, // calculation
-			{Replicas: 4, CPU: Resource{4, 4}, MemoryGB: Resource{20, 41}, Value: 81},                        // calculation
-			{Replicas: 3, CPU: Resource{4, 4}, MemoryGB: Resource{29, 58}, Value: 80},                        // calculation
-			{Replicas: 3, CPU: Resource{4, 4}, MemoryGB: Resource{20, 40}, Value: 61},                        // calculation
-			{Replicas: 2, CPU: Resource{4, 4}, MemoryGB: Resource{30, 60}, Value: 60},                        // calculation
-			{Replicas: 2, CPU: Resource{4, 4}, MemoryGB: Resource{16, 32}, Value: 32},                        // calculation
-			{Replicas: 2, CPU: Resource{4, 4}, MemoryGB: Resource{4, 8}, Value: 8},                           // calculation
-			{Replicas: 1, CPU: Resource{4, 4}, MemoryGB: Resource{8, 16}, Value: 7},                          // calculation
-			{Replicas: 1, CPU: Resource{4, 4}, MemoryGB: Resource{2, 4}, Value: LargestIndexSizeRange.Min},   // bare minimum
+		ReferencePoints: []Service{
+			{Replicas: 4, Resources: Resources{Requests: Resource{CPU: 4, MEM: 25}, Limits: Resource{CPU: 4, MEM: 50}}, Value: LargestIndexSizeRange.Max}, // calculation
+			{Replicas: 4, Resources: Resources{Requests: Resource{CPU: 4, MEM: 20}, Limits: Resource{CPU: 4, MEM: 41}}, Value: 81},                        // calculation
+			{Replicas: 3, Resources: Resources{Requests: Resource{CPU: 4, MEM: 29}, Limits: Resource{CPU: 4, MEM: 58}}, Value: 80},                        // calculation
+			{Replicas: 3, Resources: Resources{Requests: Resource{CPU: 4, MEM: 20}, Limits: Resource{CPU: 4, MEM: 40}}, Value: 61},                        // calculation
+			{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 4, MEM: 30}, Limits: Resource{CPU: 4, MEM: 60}}, Value: 60},                        // calculation
+			{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 4, MEM: 16}, Limits: Resource{CPU: 4, MEM: 32}}, Value: 32},                        // calculation
+			{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 4, MEM: 4}, Limits: Resource{CPU: 4, MEM: 8}}, Value: 8},                           // calculation
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 8}, Limits: Resource{CPU: 4, MEM: 16}}, Value: 7},                          // calculation
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 2}, Limits: Resource{CPU: 4, MEM: 4}}, Value: LargestIndexSizeRange.Min},   // bare minimum
 		},
 	},
 
@@ -71,7 +71,7 @@ var References = []ServiceScale{
 	{
 		ServiceName:   "searcher",
 		ScalingFactor: ByAverageRepositories,
-		ReferencePoints: []ReferencePoint{
+		ReferencePoints: []Service{
 			{Replicas: 8, Value: AverageRepositoriesRange.Max}, // estimate
 			{Replicas: 6, Value: 25000},                        // existing deployment: #4 & 12
 			{Replicas: 4, Value: 14000},                        // existing deployment: #51
@@ -83,11 +83,20 @@ var References = []ServiceScale{
 	{
 		ServiceName:   "searcher",
 		ScalingFactor: ByAverageRepositories,
-		ReferencePoints: []ReferencePoint{
-			{CPU: Resource{3, 6}, MemoryGB: Resource{4, 8}, Value: AverageRepositoriesRange.Max},   // estimate
-			{CPU: Resource{3, 6}, MemoryGB: Resource{4, 8}, Value: 25000},                          // existing deployment: #4
-			{CPU: Resource{.5, 2}, MemoryGB: Resource{2, 4}, Value: 4000},                          // existing deployment: #47
-			{CPU: Resource{.5, 2}, MemoryGB: Resource{.5, 2}, Value: AverageRepositoriesRange.Min}, // bare minimum
+		ReferencePoints: []Service{
+			{Resources: Resources{Requests: Resource{CPU: 3, MEM: 4}, Limits: Resource{CPU: 6, MEM: 8}}, Value: AverageRepositoriesRange.Max},   // estimate
+			{Resources: Resources{Requests: Resource{CPU: 3, MEM: 4}, Limits: Resource{CPU: 6, MEM: 8}}, Value: 25000},                          // existing deployment: #4
+			{Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}, Value: 4000},                          // existing deployment: #43
+			{Resources: Resources{Requests: Resource{CPU: .5, MEM: .5}, Limits: Resource{CPU: 2, MEM: 2}}, Value: AverageRepositoriesRange.Min}, // default
+		},
+	},
+	{
+		ServiceName:   "searcher",
+		ScalingFactor: ByAverageRepositories,
+		ReferencePoints: []Service{
+			{Resources: Resources{Requests: Resource{EPH: 25 * 19}, Limits: Resource{EPH: 26 * 19}}, Value: AverageRepositoriesRange.Max}, // existing deployment: dogfood - 4replica with 120Gi to serve 50k+ repos
+			{Resources: Resources{Requests: Resource{EPH: 25}, Limits: Resource{EPH: 26}}, Value: 4000},                                   // existing deployment: #43
+			{Resources: Resources{Requests: Resource{EPH: 25}, Limits: Resource{EPH: 26}}, Value: AverageRepositoriesRange.Min},           // default
 		},
 	},
 
@@ -96,7 +105,7 @@ var References = []ServiceScale{
 	{
 		ServiceName:   "symbols",
 		ScalingFactor: ByAverageRepositories,
-		ReferencePoints: []ReferencePoint{
+		ReferencePoints: []Service{
 			{Replicas: 4, Value: AverageRepositoriesRange.Max}, // estimate
 			{Replicas: 3, Value: 25000},                        // estimate
 			{Replicas: 2, Value: 4000},                         // estimate
@@ -106,10 +115,11 @@ var References = []ServiceScale{
 	{
 		ServiceName:   "symbols",
 		ScalingFactor: ByLargeMonorepos,
-		ReferencePoints: []ReferencePoint{
-			{CPU: Resource{2, 4}, MemoryGB: Resource{8, 16}, Value: LargeMonoreposRange.Max},  // estimate
-			{CPU: Resource{2, 4}, MemoryGB: Resource{2, 8}, Value: 2},                         // estimate
-			{CPU: Resource{.5, 2}, MemoryGB: Resource{.5, 2}, Value: LargeMonoreposRange.Min}, // bare minimum
+		ReferencePoints: []Service{
+			{Resources: Resources{Requests: Resource{CPU: 2, MEM: 8}, Limits: Resource{CPU: 4, MEM: 16}}, Value: LargeMonoreposRange.Max},  // estimate
+			{Resources: Resources{Requests: Resource{CPU: 2, MEM: 2}, Limits: Resource{CPU: 4, MEM: 8}}, Value: 4},                         // estimate
+			{Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}, Value: 2},                        // existing deployment: #43
+			{Resources: Resources{Requests: Resource{CPU: .5, MEM: .5}, Limits: Resource{CPU: 2, MEM: 2}}, Value: LargeMonoreposRange.Min}, // default
 		},
 	},
 
@@ -122,10 +132,10 @@ var References = []ServiceScale{
 	{
 		ServiceName:   "syntect-server",
 		ScalingFactor: ByEngagedUsers,
-		ReferencePoints: []ReferencePoint{
-			{Replicas: 1, CPU: Resource{2, 8}, MemoryGB: Resource{6, 12}, Value: UsersRange.Max}, // estimate
-			{Replicas: 1, CPU: Resource{.5, 4}, MemoryGB: Resource{2, 6}, Value: 5000},           // existing deployment: average between 27 and
-			{Replicas: 1, CPU: Resource{.5, 4}, MemoryGB: Resource{2, 6}, Value: UsersRange.Min}, // bare minimum
+		ReferencePoints: []Service{
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 2, MEM: 6}, Limits: Resource{CPU: 8, MEM: 12}}, Value: UsersRange.Max}, // estimate
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 4, MEM: 6}}, Value: 5000},           // existing deployment: average between 27 and
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 4, MEM: 6}}, Value: UsersRange.Min}, // default
 		},
 	},
 
@@ -133,10 +143,10 @@ var References = []ServiceScale{
 	{
 		ServiceName:   "worker",
 		ScalingFactor: ByAverageRepositories,
-		ReferencePoints: []ReferencePoint{
-			{Replicas: 1, CPU: Resource{4, 4}, MemoryGB: Resource{4, 16}, Value: AverageRepositoriesRange.Max}, // estimate
-			{Replicas: 1, CPU: Resource{4, 4}, MemoryGB: Resource{4, 8}, Value: 4000},                          // estimate
-			{Replicas: 1, CPU: Resource{.5, 2}, MemoryGB: Resource{2, 4}, Value: AverageRepositoriesRange.Min}, // bare minimum
+		ReferencePoints: []Service{
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 8}, Limits: Resource{CPU: 4, MEM: 16}}, Value: AverageRepositoriesRange.Max}, // estimate
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 4}, Limits: Resource{CPU: 4, MEM: 8}}, Value: 4000},                          // estimate
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}, Value: AverageRepositoriesRange.Min}, // default
 		},
 	},
 
@@ -144,10 +154,10 @@ var References = []ServiceScale{
 	{
 		ServiceName:   "zoekt-indexserver",
 		ScalingFactor: ByLargeMonorepos,
-		ReferencePoints: []ReferencePoint{
-			{MemoryGB: Resource{16, 16}, Value: LargeMonoreposRange.Max}, // estimate
-			{MemoryGB: Resource{16, 16}, Value: 2},                       // estimate
-			{MemoryGB: Resource{8, 8}, Value: LargeMonoreposRange.Min},   // bare minimum
+		ReferencePoints: []Service{
+			{Resources: Resources{Requests: Resource{MEM: 16}, Limits: Resource{MEM: 16}}, Value: LargeMonoreposRange.Max}, // estimate
+			{Resources: Resources{Requests: Resource{MEM: 16}, Limits: Resource{MEM: 16}}, Value: 2},                       // estimate
+			{Resources: Resources{Requests: Resource{MEM: 8}, Limits: Resource{MEM: 8}}, Value: LargeMonoreposRange.Min},   // default
 		},
 	},
 	// CPU usage and replicas scale based on the number of average repos it must index as it indexes one repo at a time
@@ -155,12 +165,12 @@ var References = []ServiceScale{
 	{
 		ServiceName:   "zoekt-indexserver",
 		ScalingFactor: ByAverageRepositories,
-		ReferencePoints: []ReferencePoint{
-			{Replicas: 4, CPU: Resource{4, 8}, Value: AverageRepositoriesRange.Max}, // estimate: at 50k repos the instance will have 4 replics so 8CPU limit per replica should be enough
-			{Replicas: 2, CPU: Resource{4, 8}, Value: 14000},                        // existing deployment: #26 - 16 CPU / 2 replicas = 8
-			{Replicas: 1, CPU: Resource{4, 8}, Value: 10000},                        // existing deployment: #37
-			{Replicas: 1, CPU: Resource{4, 8}, Value: 1500},                         // existing deployment: #44
-			{Replicas: 1, CPU: Resource{4, 8}, Value: AverageRepositoriesRange.Min}, // bare minimum
+		ReferencePoints: []Service{
+			{Replicas: 4, Resources: Resources{Requests: Resource{CPU: 4}, Limits: Resource{CPU: 8}}, Value: AverageRepositoriesRange.Max}, // estimate: 4 replics to serve 50k repos so 8CPU limit per replica should be enough
+			{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 4}, Limits: Resource{CPU: 8}}, Value: 14000},                        // existing deployment: #26 - 16 CPU / 2 replicas = 8
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4}, Limits: Resource{CPU: 8}}, Value: 10000},                        // existing deployment: #37
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4}, Limits: Resource{CPU: 8}}, Value: 1500},                         // existing deployment: #44
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4}, Limits: Resource{CPU: 8}}, Value: AverageRepositoriesRange.Min}, // default
 		},
 	},
 
@@ -169,11 +179,11 @@ var References = []ServiceScale{
 	{
 		ServiceName:   "zoekt-webserver",
 		ScalingFactor: ByAverageRepositories,
-		ReferencePoints: []ReferencePoint{
-			{Replicas: 4, MemoryGB: Resource{25, 50}, Value: AverageRepositoriesRange.Max}, // existing deployment: dogfood
-			{Replicas: 2, MemoryGB: Resource{8, 16}, Value: 14000},                         // existing deployment: #26
-			{Replicas: 1, MemoryGB: Resource{30, 60}, Value: 10000},                        // existing deployment: #37
-			{Replicas: 1, MemoryGB: Resource{4, 8}, Value: AverageRepositoriesRange.Min},   // bare minimum
+		ReferencePoints: []Service{
+			{Replicas: 4, Resources: Resources{Requests: Resource{MEM: 25}, Limits: Resource{MEM: 50}}, Value: AverageRepositoriesRange.Max}, // existing deployment: dogfood
+			{Replicas: 2, Resources: Resources{Requests: Resource{MEM: 8}, Limits: Resource{MEM: 16}}, Value: 14000},                         // existing deployment: #26
+			{Replicas: 1, Resources: Resources{Requests: Resource{MEM: 30}, Limits: Resource{MEM: 60}}, Value: 10000},                        // existing deployment: #37
+			{Replicas: 1, Resources: Resources{Requests: Resource{MEM: 4}, Limits: Resource{MEM: 8}}, Value: AverageRepositoriesRange.Min},   // default
 		},
 	},
 	// CPU usage is based on the number of users it serves (and the size of the index, but we do not account for
@@ -181,11 +191,11 @@ var References = []ServiceScale{
 	{
 		ServiceName:   "zoekt-webserver",
 		ScalingFactor: ByEngagedUsers,
-		ReferencePoints: []ReferencePoint{
-			{CPU: Resource{8, 16}, Value: UsersRange.Max}, // estimate
-			{CPU: Resource{6, 12}, Value: 15000},          // existing deployment: #51
-			{CPU: Resource{4, 8}, Value: 2100},            // existing deployment: #44
-			{CPU: Resource{.5, 2}, Value: UsersRange.Min}, // bare minimum
+		ReferencePoints: []Service{
+			{Resources: Resources{Requests: Resource{CPU: 8}, Limits: Resource{CPU: 16}}, Value: UsersRange.Max}, // estimate
+			{Resources: Resources{Requests: Resource{CPU: 6}, Limits: Resource{CPU: 12}}, Value: 15000},          // existing deployment: #51
+			{Resources: Resources{Requests: Resource{CPU: 4}, Limits: Resource{CPU: 8}}, Value: 2100},            // existing deployment: #44
+			{Resources: Resources{Requests: Resource{CPU: .5}, Limits: Resource{CPU: 2}}, Value: UsersRange.Min}, // default
 		},
 	},
 }
@@ -194,59 +204,60 @@ var References = []ServiceScale{
 // recommend the same number of replicas.
 var pods = map[string][]string{
 	"indexed-search": {"zoekt-webserver", "zoekt-indexserver"},
+	// "redis":          {"redis-cache", "redis-store"},
 }
 
-var defaults = map[string]map[string]ReferencePoint{
+var defaults = map[string]map[string]Service{
 	"frontend": {
-		"kubernetes":     ReferencePoint{Replicas: 2, CPU: Resource{2, 2}, MemoryGB: Resource{2, 4}},
-		"docker-compose": ReferencePoint{Replicas: 1, CPU: Resource{0, 4}, MemoryGB: Resource{0, 8}},
+		"kubernetes":     Service{Replicas: 2, Resources: Resources{Limits: Resource{CPU: 2, MEM: 4}, Requests: Resource{CPU: 2, MEM: 2}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 8}}},
 	},
 	"gitserver": {
-		"kubernetes":     ReferencePoint{Replicas: 1, CPU: Resource{4, 4}, MemoryGB: Resource{8, 8}},
-		"docker-compose": ReferencePoint{Replicas: 1, CPU: Resource{0, 4}, MemoryGB: Resource{0, 8}},
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 8, MEM: 8}, Requests: Resource{CPU: 4, MEM: 4}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 8}}},
 	},
 	"pgsql": {
-		"kubernetes":     ReferencePoint{Replicas: 1, CPU: Resource{4, 4}, MemoryGB: Resource{4, 4}},
-		"docker-compose": ReferencePoint{Replicas: 1, CPU: Resource{0, 4}, MemoryGB: Resource{0, 4}},
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 4}, Requests: Resource{CPU: 4, MEM: 4}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 4}}},
 	},
 	"precise-code-intel": {
-		"kubernetes":     ReferencePoint{Replicas: 2, CPU: Resource{.5, 2}, MemoryGB: Resource{2, 4}},
-		"docker-compose": ReferencePoint{Replicas: 1, CPU: Resource{0, 2}, MemoryGB: Resource{0, 4}},
-	},
-	"redis-store": {
-		"kubernetes":     ReferencePoint{Replicas: 1, CPU: Resource{1, 1}, MemoryGB: Resource{7, 7}},
-		"docker-compose": ReferencePoint{Replicas: 1, CPU: Resource{0, 1}, MemoryGB: Resource{0, 7}},
+		"kubernetes":     Service{Replicas: 2, Resources: Resources{Limits: Resource{CPU: 2, MEM: 4}, Requests: Resource{CPU: .5, MEM: 2}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 2, MEM: 4}}},
 	},
 	"redis-cache": {
-		"kubernetes":     ReferencePoint{Replicas: 1, CPU: Resource{1, 1}, MemoryGB: Resource{7, 7}},
-		"docker-compose": ReferencePoint{Replicas: 1, CPU: Resource{0, 1}, MemoryGB: Resource{0, 7}},
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 7, MEM: 7}, Requests: Resource{CPU: 1, MEM: 1}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: 7}}},
+	},
+	"redis-store": {
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 7, MEM: 7}, Requests: Resource{CPU: 1, MEM: 1}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: 7}}},
 	},
 	"repo-updater": {
-		"kubernetes":     ReferencePoint{Replicas: 1, CPU: Resource{1, 1}, MemoryGB: Resource{.5, 2}},
-		"docker-compose": ReferencePoint{Replicas: 1, CPU: Resource{0, 4}, MemoryGB: Resource{0, 4}},
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: 2}, Requests: Resource{CPU: 1, MEM: .5}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 4}}},
 	},
 	"searcher": {
-		"kubernetes":     ReferencePoint{Replicas: 2, CPU: Resource{.5, 2}, MemoryGB: Resource{.5, 2}},
-		"docker-compose": ReferencePoint{Replicas: 1, CPU: Resource{0, 2}, MemoryGB: Resource{0, 2}},
+		"kubernetes":     Service{Replicas: 2, Resources: Resources{Requests: Resource{CPU: .5, MEM: .5, EPH: 25}, Limits: Resource{CPU: 2, MEM: 2, EPH: 26}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 2, MEM: 2, EPH: 128}}},
 	},
 	"symbols": {
-		"kubernetes":     ReferencePoint{Replicas: 1, CPU: Resource{.5, 2}, MemoryGB: Resource{.5, 2}},
-		"docker-compose": ReferencePoint{Replicas: 1, CPU: Resource{0, 2}, MemoryGB: Resource{0, 4}},
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: .5, EPH: 10}, Limits: Resource{CPU: 2, MEM: 2, EPH: 12}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 2, MEM: 4, EPH: 128}}},
 	},
 	"syntect-server": {
-		"kubernetes":     ReferencePoint{Replicas: 1, CPU: Resource{.5, 4}, MemoryGB: Resource{2, 6}},
-		"docker-compose": ReferencePoint{Replicas: 1, CPU: Resource{0, 4}, MemoryGB: Resource{0, 6}},
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 5, MEM: 6}, Requests: Resource{CPU: .5, MEM: 2}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 6}}},
 	},
 	"worker": {
-		"kubernetes":     ReferencePoint{Replicas: 1, CPU: Resource{.5, 2}, MemoryGB: Resource{2, 4}},
-		"docker-compose": ReferencePoint{Replicas: 1, CPU: Resource{0, 4}, MemoryGB: Resource{0, 4}},
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 4}}},
 	},
 	"zoekt-webserver": {
-		"kubernetes":     ReferencePoint{Replicas: 1, CPU: Resource{4, 8}, MemoryGB: Resource{4, 8}},
-		"docker-compose": ReferencePoint{Replicas: 1, CPU: Resource{0, 8}, MemoryGB: Resource{0, 16}},
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 4}, Limits: Resource{CPU: 8, MEM: 8}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 8, MEM: 16}}},
 	},
 	"zoekt-indexserver": {
-		"kubernetes":     ReferencePoint{Replicas: 1, CPU: Resource{.5, 2}, MemoryGB: Resource{2, 4}},
-		"docker-compose": ReferencePoint{Replicas: 1, CPU: Resource{0, 8}, MemoryGB: Resource{0, 50}},
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 8, MEM: 50}}},
 	},
 }

--- a/internal/scaling/references.go
+++ b/internal/scaling/references.go
@@ -35,6 +35,15 @@ var References = []ServiceScale{
 		},
 	},
 
+	{
+		ServiceName:   "minio",
+		ScalingFactor: ByLargestIndexSize,
+		ReferencePoints: []Service{
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: .5}, Limits: Resource{CPU: 1, MEM: .5}}, Storage: LargestIndexSizeRange.Max, Value: LargestIndexSizeRange.Max}, // calculation
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: .5}, Limits: Resource{CPU: 1, MEM: .5}}, Storage: LargestIndexSizeRange.Min, Value: LargestIndexSizeRange.Min}, // bare minimum
+		},
+	},
+
 	// Memory usage depends on the number of active users and service-connections
 	{
 		ServiceName:   "pgsql",
@@ -52,18 +61,19 @@ var References = []ServiceScale{
 	// Scale horizontally to process a higher throughput of indexes.
 	// calculation: ~2 times of the size of the largest index
 	{
-		ServiceName:   "precise-code-intel",
+		ServiceName:   "preciseCodeIntel",
 		ScalingFactor: ByLargestIndexSize,
 		ReferencePoints: []Service{
-			{Replicas: 4, Resources: Resources{Requests: Resource{CPU: 4, MEM: 25}, Limits: Resource{CPU: 4, MEM: 50}}, Value: LargestIndexSizeRange.Max}, // calculation
-			{Replicas: 4, Resources: Resources{Requests: Resource{CPU: 4, MEM: 20}, Limits: Resource{CPU: 4, MEM: 41}}, Value: 81},                        // calculation
-			{Replicas: 3, Resources: Resources{Requests: Resource{CPU: 4, MEM: 29}, Limits: Resource{CPU: 4, MEM: 58}}, Value: 80},                        // calculation
-			{Replicas: 3, Resources: Resources{Requests: Resource{CPU: 4, MEM: 20}, Limits: Resource{CPU: 4, MEM: 40}}, Value: 61},                        // calculation
-			{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 4, MEM: 30}, Limits: Resource{CPU: 4, MEM: 60}}, Value: 60},                        // calculation
-			{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 4, MEM: 16}, Limits: Resource{CPU: 4, MEM: 32}}, Value: 32},                        // calculation
-			{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 4, MEM: 4}, Limits: Resource{CPU: 4, MEM: 8}}, Value: 8},                           // calculation
-			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 8}, Limits: Resource{CPU: 4, MEM: 16}}, Value: 7},                          // calculation
-			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 2}, Limits: Resource{CPU: 4, MEM: 4}}, Value: LargestIndexSizeRange.Min},   // bare minimum
+			{Replicas: 4, Resources: Resources{Requests: Resource{CPU: 2, MEM: 25}, Limits: Resource{CPU: 4, MEM: 50}}, Value: LargestIndexSizeRange.Max}, // calculation
+			{Replicas: 4, Resources: Resources{Requests: Resource{CPU: 2, MEM: 20}, Limits: Resource{CPU: 4, MEM: 41}}, Value: 81},                        // calculation
+			{Replicas: 3, Resources: Resources{Requests: Resource{CPU: 2, MEM: 29}, Limits: Resource{CPU: 4, MEM: 58}}, Value: 80},                        // calculation
+			{Replicas: 3, Resources: Resources{Requests: Resource{CPU: 2, MEM: 20}, Limits: Resource{CPU: 4, MEM: 40}}, Value: 61},                        // calculation
+			{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 2, MEM: 30}, Limits: Resource{CPU: 4, MEM: 60}}, Value: 60},                        // calculation
+			{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 2, MEM: 16}, Limits: Resource{CPU: 4, MEM: 32}}, Value: 32},                        // calculation
+			{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 2, MEM: 4}, Limits: Resource{CPU: 4, MEM: 8}}, Value: 8},                           // calculation
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 2, MEM: 8}, Limits: Resource{CPU: 4, MEM: 16}}, Value: 7},                          // calculation
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}, Value: 1},                          // default
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}, Value: LargestIndexSizeRange.Min},  // bare minimum
 		},
 	},
 
@@ -130,7 +140,7 @@ var References = []ServiceScale{
 	// These can cause runaway CPU usage (for 1 core per hang).
 	// syntect-server should normally kill such processes and restart them if that happens.
 	{
-		ServiceName:   "syntect-server",
+		ServiceName:   "syntectServer",
 		ScalingFactor: ByEngagedUsers,
 		ReferencePoints: []Service{
 			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 2, MEM: 6}, Limits: Resource{CPU: 8, MEM: 12}}, Value: UsersRange.Max}, // estimate
@@ -144,26 +154,26 @@ var References = []ServiceScale{
 		ServiceName:   "worker",
 		ScalingFactor: ByAverageRepositories,
 		ReferencePoints: []Service{
-			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 8}, Limits: Resource{CPU: 4, MEM: 16}}, Value: AverageRepositoriesRange.Max}, // estimate
-			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 4}, Limits: Resource{CPU: 4, MEM: 8}}, Value: 4000},                          // estimate
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 2, MEM: 8}, Limits: Resource{CPU: 4, MEM: 16}}, Value: AverageRepositoriesRange.Max}, // estimate
+			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 2, MEM: 4}, Limits: Resource{CPU: 4, MEM: 8}}, Value: 25000},                         // estimate
 			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}, Value: AverageRepositoriesRange.Min}, // default
 		},
 	},
 
 	// zoekt-indexserver memory usage scales based on whether it must index large monorepos
 	{
-		ServiceName:   "zoekt-indexserver",
+		ServiceName:   "indexedSearch",
 		ScalingFactor: ByLargeMonorepos,
 		ReferencePoints: []Service{
-			{Resources: Resources{Requests: Resource{MEM: 16}, Limits: Resource{MEM: 16}}, Value: LargeMonoreposRange.Max}, // estimate
-			{Resources: Resources{Requests: Resource{MEM: 16}, Limits: Resource{MEM: 16}}, Value: 2},                       // estimate
-			{Resources: Resources{Requests: Resource{MEM: 8}, Limits: Resource{MEM: 8}}, Value: LargeMonoreposRange.Min},   // default
+			{Resources: Resources{Requests: Resource{MEM: 8}, Limits: Resource{MEM: 16}}, Value: LargeMonoreposRange.Max}, // estimate
+			{Resources: Resources{Requests: Resource{MEM: 8}, Limits: Resource{MEM: 16}}, Value: 2},                       // estimate
+			{Resources: Resources{Requests: Resource{MEM: 4}, Limits: Resource{MEM: 8}}, Value: LargeMonoreposRange.Min},  // default
 		},
 	},
 	// CPU usage and replicas scale based on the number of average repos it must index as it indexes one repo at a time
 	// Set replica number to 0 as it will be synced with the replica number for webserver
 	{
-		ServiceName:   "zoekt-indexserver",
+		ServiceName:   "indexedSearch",
 		ScalingFactor: ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Replicas: 4, Resources: Resources{Requests: Resource{CPU: 4}, Limits: Resource{CPU: 8}}, Value: AverageRepositoriesRange.Max}, // estimate: 4 replics to serve 50k repos so 8CPU limit per replica should be enough
@@ -177,7 +187,7 @@ var References = []ServiceScale{
 	// zoekt-webserver memory usage and replicas scale based on how many average repositories it is
 	// serving (roughly 2/3 the size of the actual repos is the memory usage).
 	{
-		ServiceName:   "zoekt-webserver",
+		ServiceName:   "indexedSearchIndexer",
 		ScalingFactor: ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Replicas: 4, Resources: Resources{Requests: Resource{MEM: 25}, Limits: Resource{MEM: 50}}, Value: AverageRepositoriesRange.Max}, // existing deployment: dogfood
@@ -189,7 +199,7 @@ var References = []ServiceScale{
 	// CPU usage is based on the number of users it serves (and the size of the index, but we do not account for
 	// that here and instead assume a correlation between # users and # repos which is generally true.)
 	{
-		ServiceName:   "zoekt-webserver",
+		ServiceName:   "indexedSearchIndexer",
 		ScalingFactor: ByEngagedUsers,
 		ReferencePoints: []Service{
 			{Resources: Resources{Requests: Resource{CPU: 8}, Limits: Resource{CPU: 16}}, Value: UsersRange.Max}, // estimate
@@ -203,37 +213,41 @@ var References = []ServiceScale{
 // pods list services which live in the same pod. This is used to ensure we
 // recommend the same number of replicas.
 var pods = map[string][]string{
-	"indexed-search": {"zoekt-webserver", "zoekt-indexserver"},
+	"indexed-search": {"indexedSearch", "indexedSearchIndexer"},
 	// "redis":          {"redis-cache", "redis-store"},
 }
 
 var defaults = map[string]map[string]Service{
 	"frontend": {
-		"kubernetes":     Service{Replicas: 2, Resources: Resources{Limits: Resource{CPU: 2, MEM: 4}, Requests: Resource{CPU: 2, MEM: 2}}},
+		"kubernetes":     Service{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 2, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}},
 		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 8}}},
 	},
 	"gitserver": {
-		"kubernetes":     Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 8, MEM: 8}, Requests: Resource{CPU: 4, MEM: 4}}},
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 4}, Limits: Resource{CPU: 8, MEM: 8}}},
 		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 8}}},
 	},
 	"pgsql": {
-		"kubernetes":     Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 4}, Requests: Resource{CPU: 4, MEM: 4}}},
-		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 4}}},
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 4}, Limits: Resource{CPU: 4, MEM: 4}}, Storage: 200},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 4}}, Storage: 200},
 	},
-	"precise-code-intel": {
-		"kubernetes":     Service{Replicas: 2, Resources: Resources{Limits: Resource{CPU: 2, MEM: 4}, Requests: Resource{CPU: .5, MEM: 2}}},
+	"preciseCodeIntel": {
+		"kubernetes":     Service{Replicas: 2, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}},
 		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 2, MEM: 4}}},
 	},
-	"redis-cache": {
-		"kubernetes":     Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 7, MEM: 7}, Requests: Resource{CPU: 1, MEM: 1}}},
+	"minio": {
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: .5}, Limits: Resource{CPU: 1, MEM: .5}}, Storage: 100},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: .5}}, Storage: 100},
+	},
+	"redisCache": {
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: 1}, Limits: Resource{CPU: 7, MEM: 7}}},
 		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: 7}}},
 	},
-	"redis-store": {
-		"kubernetes":     Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 7, MEM: 7}, Requests: Resource{CPU: 1, MEM: 1}}},
+	"redisStore": {
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: 1}, Limits: Resource{CPU: 7, MEM: 7}}},
 		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: 7}}},
 	},
-	"repo-updater": {
-		"kubernetes":     Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: 2}, Requests: Resource{CPU: 1, MEM: .5}}},
+	"repoUpdater": {
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: .5}, Limits: Resource{CPU: 1, MEM: 2}}},
 		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 4}}},
 	},
 	"searcher": {
@@ -244,19 +258,19 @@ var defaults = map[string]map[string]Service{
 		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: .5, EPH: 10}, Limits: Resource{CPU: 2, MEM: 2, EPH: 12}}},
 		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 2, MEM: 4, EPH: 128}}},
 	},
-	"syntect-server": {
-		"kubernetes":     Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 5, MEM: 6}, Requests: Resource{CPU: .5, MEM: 2}}},
+	"syntectServer": {
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 5, MEM: 6}}},
 		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 6}}},
 	},
 	"worker": {
 		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}},
 		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 4}}},
 	},
-	"zoekt-webserver": {
+	"indexedSearchIndexer": { // zoekt-webserver
 		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 4}, Limits: Resource{CPU: 8, MEM: 8}}},
 		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 8, MEM: 16}}},
 	},
-	"zoekt-indexserver": {
+	"indexedSearch": { // zoekt-indexserver
 		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}},
 		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 8, MEM: 50}}},
 	},

--- a/internal/scaling/references.go
+++ b/internal/scaling/references.go
@@ -266,59 +266,92 @@ var pods = map[string][]string{
 }
 
 var defaults = map[string]map[string]Service{
+	"cadvisor": {
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .15, MEM: .2}, Limits: Resource{CPU: .3, MEM: .2}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: 1}}},
+	},
+	"codeinsights-db": {
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 2, MEM: 2}, Limits: Resource{CPU: 4, MEM: 4}}, Storage: 200},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 2, MEM: 4}}, Storage: 128},
+	},
+	"codeintel-db": {
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 4}, Limits: Resource{CPU: 4, MEM: 4}}, Storage: 200},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 4}}, Storage: 128},
+	},
 	"frontend": {
-		"kubernetes":     Service{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 2, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}},
-		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 8}}},
+		"kubernetes":     Service{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 2, MEM: 2, EPH: 4}, Limits: Resource{CPU: 2, MEM: 4, EPH: 8}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 8}}, Storage: 128},
+	},
+	"frontend-internal": {
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 8}}, Storage: 128},
+	},
+	"github-proxy": {
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .1, MEM: .25}, Limits: Resource{CPU: 1, MEM: 1}}, Storage: 200},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: 1}}, Storage: 1},
 	},
 	"gitserver": {
-		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 4}, Limits: Resource{CPU: 8, MEM: 8}}},
-		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 8}}},
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 8}, Limits: Resource{CPU: 4, MEM: 8}}, Storage: 200},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 8}}, Storage: 200},
+	},
+	"grafana": {
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .1, MEM: .512}, Limits: Resource{CPU: 1, MEM: .512}}, Storage: 2},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: 1}}, Storage: 2},
+	},
+	"jaeger": {
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: .5}, Limits: Resource{CPU: 1, MEM: 1}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: .5, MEM: .512}}, Storage: 128},
 	},
 	"pgsql": {
 		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 4}, Limits: Resource{CPU: 4, MEM: 4}}, Storage: 200},
-		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 4}}, Storage: 200},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 4}}, Storage: 128},
 	},
 	"preciseCodeIntel": {
 		"kubernetes":     Service{Replicas: 2, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}},
 		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 2, MEM: 4}}},
 	},
+	"prometheus": {
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 6}, Limits: Resource{CPU: 2, MEM: 6}}, Storage: 200},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 8}}, Storage: 200},
+	},
 	"minio": {
 		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: .5}, Limits: Resource{CPU: 1, MEM: .5}}, Storage: 100},
-		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: .5}}, Storage: 100},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: 1}}, Storage: 128},
 	},
 	"redisCache": {
-		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: 1}, Limits: Resource{CPU: 7, MEM: 7}}},
-		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: 7}}},
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: 7}, Limits: Resource{CPU: 1, MEM: 7}}, Storage: 100},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: 7}}, Storage: 128},
 	},
 	"redisStore": {
-		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: 1}, Limits: Resource{CPU: 7, MEM: 7}}},
-		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: 7}}},
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: 7}, Limits: Resource{CPU: 1, MEM: 7}}, Storage: 100},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: 7}}, Storage: 128},
 	},
 	"repoUpdater": {
 		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: .5}, Limits: Resource{CPU: 1, MEM: 2}}},
-		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 4}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 4}}, Storage: 128},
 	},
 	"searcher": {
 		"kubernetes":     Service{Replicas: 2, Resources: Resources{Requests: Resource{CPU: .5, MEM: .5, EPH: 25}, Limits: Resource{CPU: 2, MEM: 2, EPH: 26}}},
-		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 2, MEM: 2, EPH: 128}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 2, MEM: 2}}, Storage: 128},
 	},
 	"symbols": {
 		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: .5, EPH: 10}, Limits: Resource{CPU: 2, MEM: 2, EPH: 12}}},
-		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 2, MEM: 4, EPH: 128}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 2, MEM: 4}}, Storage: 128},
 	},
 	"syntectServer": {
-		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 5, MEM: 6}}},
-		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 6}}},
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .25, MEM: 2}, Limits: Resource{CPU: 4, MEM: 6}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 6}}}, // no disk
 	},
 	"worker": {
 		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}},
-		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 4}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 4}}, Storage: 128},
 	},
-	"indexedSearchIndexer": { // zoekt-webserver
-		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 4}, Limits: Resource{CPU: 8, MEM: 8}}},
+	// zoekt-webserver
+	"indexedSearchIndexer": {
+		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 4}, Limits: Resource{CPU: 8, MEM: 8}}, Storage: 200},
 		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 8, MEM: 16}}, Storage: 200},
 	},
-	"indexedSearch": { // zoekt-indexserver
+	// zoekt-indexserver
+	"indexedSearch": {
 		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}},
 		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 8, MEM: 50}}, Storage: 200},
 	},

--- a/internal/scaling/references.go
+++ b/internal/scaling/references.go
@@ -7,8 +7,9 @@ var References = []ServiceScale{
 	// Frontend scales based on the number of engaged users.
 	// Add 2000 users to user count if code-insight is enabled
 	{
-		ServiceName:   "frontend",
-		ScalingFactor: ByEngagedUsers, // UsersRange = {5, 10000}
+		ServiceName:       "frontend",
+		DockerServiceName: "sourcegraph-frontend-0",
+		ScalingFactor:     ByEngagedUsers, // UsersRange = {5, 10000}
 		ReferencePoints: []Service{
 			{Replicas: 5, Resources: Resources{Requests: Resource{CPU: 2, MEM: 8}, Limits: Resource{CPU: 4, MEM: 16}}, Value: UsersRange.Max}, // estimate
 			{Replicas: 3, Resources: Resources{Requests: Resource{CPU: 4, MEM: 8}, Limits: Resource{CPU: 8, MEM: 16}}, Value: 5000},           // estimate
@@ -20,8 +21,9 @@ var References = []ServiceScale{
 
 	// Gitserver scales based on the total size of all repoes and number of average repositories.
 	{
-		ServiceName:   "gitserver",
-		ScalingFactor: ByUserRepoSumRatio,
+		ServiceName:       "gitserver",
+		DockerServiceName: "gitserver-0",
+		ScalingFactor:     ByUserRepoSumRatio,
 		ReferencePoints: []Service{
 			{Replicas: 5, Resources: Resources{Requests: Resource{CPU: 16, MEM: 32}, Limits: Resource{CPU: 16, MEM: 32}}, Value: UserRepoSumRatioRange.Max}, // estimate
 			{Replicas: 4, Resources: Resources{Requests: Resource{CPU: 16, MEM: 32}, Limits: Resource{CPU: 16, MEM: 32}}, Value: 150},                       // estimate
@@ -36,8 +38,9 @@ var References = []ServiceScale{
 	},
 
 	{
-		ServiceName:   "minio",
-		ScalingFactor: ByLargestIndexSize,
+		ServiceName:       "minio",
+		DockerServiceName: "minio",
+		ScalingFactor:     ByLargestIndexSize,
 		ReferencePoints: []Service{
 			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: .5}, Limits: Resource{CPU: 1, MEM: .5}}, Storage: LargestIndexSizeRange.Max, Value: LargestIndexSizeRange.Max}, // calculation
 			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: .5}, Limits: Resource{CPU: 1, MEM: .5}}, Storage: LargestIndexSizeRange.Min, Value: LargestIndexSizeRange.Min}, // bare minimum
@@ -46,8 +49,9 @@ var References = []ServiceScale{
 
 	// Memory usage depends on the number of active users and service-connections
 	{
-		ServiceName:   "pgsql",
-		ScalingFactor: ByAverageRepositories,
+		ServiceName:       "pgsql",
+		DockerServiceName: "pgsql",
+		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 7, MEM: 32}, Limits: Resource{CPU: 7, MEM: 32}}, Value: AverageRepositoriesRange.Max}, // existing deployment: dogfood
 			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 16}, Limits: Resource{CPU: 4, MEM: 16}}, Value: 25000},                        // existing deployment: #4
@@ -61,8 +65,9 @@ var References = []ServiceScale{
 	// Scale horizontally to process a higher throughput of indexes.
 	// calculation: ~2 times of the size of the largest index
 	{
-		ServiceName:   "preciseCodeIntel",
-		ScalingFactor: ByLargestIndexSize,
+		ServiceName:       "preciseCodeIntel",
+		DockerServiceName: "precise-code-intel-worker",
+		ScalingFactor:     ByLargestIndexSize,
 		ReferencePoints: []Service{
 			{Replicas: 4, Resources: Resources{Requests: Resource{CPU: 2, MEM: 25}, Limits: Resource{CPU: 4, MEM: 50}}, Value: LargestIndexSizeRange.Max}, // calculation
 			{Replicas: 4, Resources: Resources{Requests: Resource{CPU: 2, MEM: 20}, Limits: Resource{CPU: 4, MEM: 41}}, Value: 81},                        // calculation
@@ -79,8 +84,9 @@ var References = []ServiceScale{
 
 	// Searcher replicas scale based the number of concurrent unidexed queries & number concurrent of structural searches
 	{
-		ServiceName:   "searcher",
-		ScalingFactor: ByAverageRepositories,
+		ServiceName:       "searcher",
+		DockerServiceName: "searcher-0",
+		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Replicas: 8, Value: AverageRepositoriesRange.Max}, // estimate
 			{Replicas: 6, Value: 25000},                        // existing deployment: #4 & 12
@@ -91,8 +97,9 @@ var References = []ServiceScale{
 	// Searcher is IO and CPU bound. It fetches archives from gitserver and searches them with regexp.
 	// Memory scales based on the size of repositories (i.e. when large monorepos are in the picture).
 	{
-		ServiceName:   "searcher",
-		ScalingFactor: ByAverageRepositories,
+		ServiceName:       "searcher",
+		DockerServiceName: "searcher-0",
+		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Resources: Resources{Requests: Resource{CPU: 3, MEM: 4}, Limits: Resource{CPU: 6, MEM: 8}}, Value: AverageRepositoriesRange.Max},   // estimate
 			{Resources: Resources{Requests: Resource{CPU: 3, MEM: 4}, Limits: Resource{CPU: 6, MEM: 8}}, Value: 25000},                          // existing deployment: #4
@@ -101,8 +108,9 @@ var References = []ServiceScale{
 		},
 	},
 	{
-		ServiceName:   "searcher",
-		ScalingFactor: ByAverageRepositories,
+		ServiceName:       "searcher",
+		DockerServiceName: "searcher-0",
+		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Resources: Resources{Requests: Resource{EPH: 25 * 19}, Limits: Resource{EPH: 26 * 19}}, Value: AverageRepositoriesRange.Max}, // existing deployment: dogfood - 4replica with 120Gi to serve 50k+ repos
 			{Resources: Resources{Requests: Resource{EPH: 25}, Limits: Resource{EPH: 26}}, Value: 4000},                                   // existing deployment: #43
@@ -113,8 +121,9 @@ var References = []ServiceScale{
 	// Symbols replicas scale based on the number of average repositories, and its resources scale
 	// based on the size of repositories (i.e. when large monorepos are in the picture).
 	{
-		ServiceName:   "symbols",
-		ScalingFactor: ByAverageRepositories,
+		ServiceName:       "symbols",
+		DockerServiceName: "symbols-0",
+		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Replicas: 4, Value: AverageRepositoriesRange.Max}, // estimate
 			{Replicas: 3, Value: 25000},                        // estimate
@@ -123,8 +132,9 @@ var References = []ServiceScale{
 		},
 	},
 	{
-		ServiceName:   "symbols",
-		ScalingFactor: ByLargeMonorepos,
+		ServiceName:       "symbols",
+		DockerServiceName: "symbols-0",
+		ScalingFactor:     ByLargeMonorepos,
 		ReferencePoints: []Service{
 			{Resources: Resources{Requests: Resource{CPU: 2, MEM: 8}, Limits: Resource{CPU: 4, MEM: 16}}, Value: LargeMonoreposRange.Max},  // estimate
 			{Resources: Resources{Requests: Resource{CPU: 2, MEM: 2}, Limits: Resource{CPU: 4, MEM: 8}}, Value: 4},                         // estimate
@@ -140,8 +150,9 @@ var References = []ServiceScale{
 	// These can cause runaway CPU usage (for 1 core per hang).
 	// syntect-server should normally kill such processes and restart them if that happens.
 	{
-		ServiceName:   "syntectServer",
-		ScalingFactor: ByEngagedUsers,
+		ServiceName:       "syntectServer",
+		DockerServiceName: "syntect-server",
+		ScalingFactor:     ByEngagedUsers,
 		ReferencePoints: []Service{
 			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 2, MEM: 6}, Limits: Resource{CPU: 8, MEM: 12}}, Value: UsersRange.Max}, // estimate
 			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 4, MEM: 6}}, Value: 5000},           // existing deployment: average between 27 and
@@ -151,8 +162,9 @@ var References = []ServiceScale{
 
 	// worker is used by different services, and mostly scale based on the number of average repositories to execute jobs
 	{
-		ServiceName:   "worker",
-		ScalingFactor: ByAverageRepositories,
+		ServiceName:       "worker",
+		DockerServiceName: "worker",
+		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 2, MEM: 8}, Limits: Resource{CPU: 4, MEM: 16}}, Value: AverageRepositoriesRange.Max}, // estimate
 			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 2, MEM: 4}, Limits: Resource{CPU: 4, MEM: 8}}, Value: 25000},                         // estimate
@@ -162,8 +174,9 @@ var References = []ServiceScale{
 
 	// zoekt-indexserver memory usage scales based on whether it must index large monorepos
 	{
-		ServiceName:   "indexedSearch",
-		ScalingFactor: ByLargeMonorepos,
+		ServiceName:       "indexedSearch",
+		DockerServiceName: "zoekt-indexserver-0",
+		ScalingFactor:     ByLargeMonorepos,
 		ReferencePoints: []Service{
 			{Resources: Resources{Requests: Resource{MEM: 8}, Limits: Resource{MEM: 16}}, Value: LargeMonoreposRange.Max}, // estimate
 			{Resources: Resources{Requests: Resource{MEM: 8}, Limits: Resource{MEM: 16}}, Value: 2},                       // estimate
@@ -173,8 +186,9 @@ var References = []ServiceScale{
 	// CPU usage and replicas scale based on the number of average repos it must index as it indexes one repo at a time
 	// Set replica number to 0 as it will be synced with the replica number for webserver
 	{
-		ServiceName:   "indexedSearch",
-		ScalingFactor: ByAverageRepositories,
+		ServiceName:       "indexedSearch",
+		DockerServiceName: "zoekt-indexserver-0",
+		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Replicas: 4, Resources: Resources{Requests: Resource{CPU: 4}, Limits: Resource{CPU: 8}}, Value: AverageRepositoriesRange.Max}, // estimate: 4 replics to serve 50k repos so 8CPU limit per replica should be enough
 			{Replicas: 2, Resources: Resources{Requests: Resource{CPU: 4}, Limits: Resource{CPU: 8}}, Value: 14000},                        // existing deployment: #26 - 16 CPU / 2 replicas = 8
@@ -187,8 +201,9 @@ var References = []ServiceScale{
 	// zoekt-webserver memory usage and replicas scale based on how many average repositories it is
 	// serving (roughly 2/3 the size of the actual repos is the memory usage).
 	{
-		ServiceName:   "indexedSearchIndexer",
-		ScalingFactor: ByAverageRepositories,
+		ServiceName:       "indexedSearchIndexer",
+		DockerServiceName: "zoekt-webserver-0",
+		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
 			{Replicas: 4, Resources: Resources{Requests: Resource{MEM: 25}, Limits: Resource{MEM: 50}}, Value: AverageRepositoriesRange.Max}, // existing deployment: dogfood
 			{Replicas: 2, Resources: Resources{Requests: Resource{MEM: 8}, Limits: Resource{MEM: 16}}, Value: 14000},                         // existing deployment: #26
@@ -199,8 +214,9 @@ var References = []ServiceScale{
 	// CPU usage is based on the number of users it serves (and the size of the index, but we do not account for
 	// that here and instead assume a correlation between # users and # repos which is generally true.)
 	{
-		ServiceName:   "indexedSearchIndexer",
-		ScalingFactor: ByEngagedUsers,
+		ServiceName:       "indexedSearchIndexer",
+		DockerServiceName: "zoekt-webserver-0",
+		ScalingFactor:     ByEngagedUsers,
 		ReferencePoints: []Service{
 			{Resources: Resources{Requests: Resource{CPU: 8}, Limits: Resource{CPU: 16}}, Value: UsersRange.Max}, // estimate
 			{Resources: Resources{Requests: Resource{CPU: 6}, Limits: Resource{CPU: 12}}, Value: 15000},          // existing deployment: #51
@@ -214,7 +230,6 @@ var References = []ServiceScale{
 // recommend the same number of replicas.
 var pods = map[string][]string{
 	"indexed-search": {"indexedSearch", "indexedSearchIndexer"},
-	// "redis":          {"redis-cache", "redis-store"},
 }
 
 var defaults = map[string]map[string]Service{
@@ -268,10 +283,10 @@ var defaults = map[string]map[string]Service{
 	},
 	"indexedSearchIndexer": { // zoekt-webserver
 		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 4, MEM: 4}, Limits: Resource{CPU: 8, MEM: 8}}},
-		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 8, MEM: 16}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 8, MEM: 16}}, Storage: 200},
 	},
 	"indexedSearch": { // zoekt-indexserver
 		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}},
-		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 8, MEM: 50}}},
+		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 8, MEM: 50}}, Storage: 200},
 	},
 }

--- a/internal/scaling/references.go
+++ b/internal/scaling/references.go
@@ -88,9 +88,7 @@ var References = []ServiceScale{
 		DockerServiceName: "searcher-0",
 		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
-			{Replicas: 8, Value: AverageRepositoriesRange.Max}, // estimate
-			{Replicas: 6, Value: 25000},                        // existing deployment: #4 & 12
-			{Replicas: 4, Value: 14000},                        // existing deployment: #51
+			{Replicas: 4, Value: AverageRepositoriesRange.Max}, // existing deployment: dogfood
 			{Replicas: 1, Value: AverageRepositoriesRange.Min}, // bare minimum
 		},
 	},
@@ -101,20 +99,10 @@ var References = []ServiceScale{
 		DockerServiceName: "searcher-0",
 		ScalingFactor:     ByAverageRepositories,
 		ReferencePoints: []Service{
-			{Resources: Resources{Requests: Resource{CPU: 3, MEM: 4}, Limits: Resource{CPU: 6, MEM: 8}}, Value: AverageRepositoriesRange.Max},   // estimate
-			{Resources: Resources{Requests: Resource{CPU: 3, MEM: 4}, Limits: Resource{CPU: 6, MEM: 8}}, Value: 25000},                          // existing deployment: #4
-			{Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}, Value: 4000},                          // existing deployment: #43
-			{Resources: Resources{Requests: Resource{CPU: .5, MEM: .5}, Limits: Resource{CPU: 2, MEM: 2}}, Value: AverageRepositoriesRange.Min}, // default
-		},
-	},
-	{
-		ServiceName:       "searcher",
-		DockerServiceName: "searcher-0",
-		ScalingFactor:     ByAverageRepositories,
-		ReferencePoints: []Service{
-			{Resources: Resources{Requests: Resource{EPH: 25 * 19}, Limits: Resource{EPH: 26 * 19}}, Value: AverageRepositoriesRange.Max}, // existing deployment: dogfood - 4replica with 120Gi to serve 50k+ repos
-			{Resources: Resources{Requests: Resource{EPH: 25}, Limits: Resource{EPH: 26}}, Value: 4000},                                   // existing deployment: #43
-			{Resources: Resources{Requests: Resource{EPH: 25}, Limits: Resource{EPH: 26}}, Value: AverageRepositoriesRange.Min},           // default
+			{Resources: Resources{Requests: Resource{CPU: 3, MEM: 4, EPH: 440}, Limits: Resource{CPU: 6, MEM: 8, EPH: 480}}, Value: AverageRepositoriesRange.Max}, // estimate. eph based on dogfood
+			{Resources: Resources{Requests: Resource{CPU: 3, MEM: 4, EPH: 220}, Limits: Resource{CPU: 6, MEM: 8, EPH: 240}}, Value: 25000},                        // existing deployment: #4
+			{Resources: Resources{Requests: Resource{CPU: .5, MEM: 2, EPH: 25}, Limits: Resource{CPU: 2, MEM: 4, EPH: 26}}, Value: 4000},                          // existing deployment: #43
+			{Resources: Resources{Requests: Resource{CPU: .5, MEM: .5, EPH: 25}, Limits: Resource{CPU: 2, MEM: 2, EPH: 26}}, Value: AverageRepositoriesRange.Min}, // default
 		},
 	},
 
@@ -137,9 +125,22 @@ var References = []ServiceScale{
 		ScalingFactor:     ByLargeMonorepos,
 		ReferencePoints: []Service{
 			{Resources: Resources{Requests: Resource{CPU: 2, MEM: 8}, Limits: Resource{CPU: 4, MEM: 16}}, Value: LargeMonoreposRange.Max},  // estimate
-			{Resources: Resources{Requests: Resource{CPU: 2, MEM: 2}, Limits: Resource{CPU: 4, MEM: 8}}, Value: 4},                         // estimate
+			{Resources: Resources{Requests: Resource{CPU: 2, MEM: 4}, Limits: Resource{CPU: 4, MEM: 8}}, Value: 4},                         // estimate
 			{Resources: Resources{Requests: Resource{CPU: .5, MEM: 2}, Limits: Resource{CPU: 2, MEM: 4}}, Value: 2},                        // existing deployment: #43
 			{Resources: Resources{Requests: Resource{CPU: .5, MEM: .5}, Limits: Resource{CPU: 2, MEM: 2}}, Value: LargeMonoreposRange.Min}, // default
+		},
+	},
+	{
+		ServiceName:       "symbols",
+		DockerServiceName: "symbols-0",
+		ScalingFactor:     ByLargestRepoSize,
+		ReferencePoints: []Service{
+			{Resources: Resources{Requests: Resource{EPH: 5900}, Limits: Resource{EPH: 6000}}, Value: LargestRepoSizeRange.Max}, // calculation
+			{Resources: Resources{Requests: Resource{EPH: 110}, Limits: Resource{EPH: 120}}, Value: 100},                        // calculation
+			{Resources: Resources{Requests: Resource{EPH: 50}, Limits: Resource{EPH: 60}}, Value: 50},                           // calculation
+			{Resources: Resources{Requests: Resource{EPH: 5}, Limits: Resource{EPH: 6}}, Value: 5},                              // calculation
+			{Resources: Resources{Requests: Resource{EPH: 2}, Limits: Resource{EPH: 3}}, Value: 2},                              // calculation
+			{Resources: Resources{Requests: Resource{EPH: 1}, Limits: Resource{EPH: 2}}, Value: LargestRepoSizeRange.Min},       // bare minimum
 		},
 	},
 

--- a/internal/scaling/scaling.go
+++ b/internal/scaling/scaling.go
@@ -391,8 +391,7 @@ func (e *Estimate) MarkdownExport() []byte {
 		fmt.Fprintf(&buf, "* **Estimated total memory:** not available\n")
 		fmt.Fprintf(&buf, "* **Estimated total storage:** not available\n")
 	}
-	fmt.Fprintf(&buf, "\n**Note:** The total estimated numbers shown above include default values for other services.\n")
-	fmt.Fprintf(&buf, "Use the default values for services not listed below.\n")
+	fmt.Fprintf(&buf, "\n<small>**Note:** The estimated total includes default values for other services.</small>\n")
 	if e.EngagedUsers < 650/2 && e.AverageRepositories < 1500/2 {
 		if e.DeploymentType == "docker-compose" {
 			fmt.Fprintf(&buf, "* <details><summary>**IMPORTANT:** Cost-saving option to reduce resource consumption is available</summary><br><blockquote>\n")

--- a/internal/scaling/scaling.go
+++ b/internal/scaling/scaling.go
@@ -124,10 +124,10 @@ func (r Service) join(o Service) Service {
 		r.Resources.Limits.MEMS = addUnit(o.Resources.Limits.MEM, "MEM")
 	}
 	if o.Resources.Limits.EPH > 0 && (ResourceRange{r.Resources.Requests.EPH, r.Resources.Limits.EPH}) == (ResourceRange{}) {
-		r.Resources.Requests.EPH = math.Trunc((o.Resources.Limits.EPH - 2*float64(o.Replicas)) / float64(o.Replicas))
-		r.Resources.Limits.EPH = math.Trunc(o.Resources.Limits.EPH / float64(o.Replicas))
+		r.Resources.Requests.EPH = o.Resources.Requests.EPH / float64(r.Replicas)
+		r.Resources.Limits.EPH = o.Resources.Limits.EPH / float64(r.Replicas)
 		r.Resources.Requests.EPHS = addUnit(r.Resources.Requests.EPH, "EPH")
-		r.Resources.Limits.EPHS = addUnit(r.Resources.Limits.EPH, "EPH")
+		r.Resources.Limits.EPHS = addUnit(math.Round(r.Resources.Limits.EPH), "EPH")
 	}
 	if o.Storage > 0 {
 		r.Storage = o.Storage
@@ -336,10 +336,6 @@ func (e *Estimate) Calculate() *Estimate {
 			v.Storage = float64(e.TotalRepoSize * 120 / 100 / 2 / dockerFactor)
 		case "indexedSearchIndexer":
 			v.Storage = float64(e.TotalRepoSize * 120 / 100 / 2 / dockerFactor * k8sFactor)
-		case "searcher":
-			v.Resources.Limits.EPH = float64(e.AverageRepositories / 100)
-		case "symbols":
-			v.Resources.Limits.EPH = float64(e.LargestRepoSize * 120 / 100)
 		}
 		e.Services[ref.ServiceName] = e.Services[ref.ServiceName].join(v)
 		e.DockerServices[ref.DockerServiceName] = e.DockerServices[ref.ServiceName].join(e.Services[ref.ServiceName])

--- a/internal/scaling/scaling.go
+++ b/internal/scaling/scaling.go
@@ -376,7 +376,7 @@ func (e *Estimate) Calculate() *Estimate {
 	return e
 }
 
-func (e *Estimate) Result() []byte {
+func (e *Estimate) MarkdownExport() []byte {
 	var buf bytes.Buffer
 	// Summary of the output
 	fmt.Fprintf(&buf, "### Estimate summary\n")

--- a/internal/scaling/scaling_test.go
+++ b/internal/scaling/scaling_test.go
@@ -44,7 +44,7 @@ func TestEstimate(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			got := string(tc.Estimate.Calculate().Result())
+			got := string(tc.Estimate.Calculate().MarkdownExport())
 			autogold.Equal(t, got)
 		})
 	}
@@ -59,7 +59,7 @@ func TestInvariants(t *testing.T) {
 
 		if e.Services["zoekt-webserver"].Replicas != e.Services["zoekt-indexserver"].Replicas {
 			t.Log("zoekt-webserver replicas != zoekt-indexserver replicas but they live in the same pod")
-			t.Log(string(e.Result()))
+			t.Log(string(e.MarkdownExport()))
 			return false
 		}
 

--- a/internal/scaling/testdata/TestEstimate/default.golden
+++ b/internal/scaling/testdata/TestEstimate/default.golden
@@ -17,17 +17,17 @@
 
 | Service | Replica | CPU requests | CPU limits | MEM requests | MEM limits | Ephemeral Requests/Limits | Storage |
 |-------|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|
-| frontend | 2ꜝ | - | 4 | - | 8G | - | - |
-| gitserver | 1 | - | 4 | - | 8G | - | 36Giꜝ |
-| zoekt-indexserver | 1 | - | 8 | - | 8Gꜝ | - | 18Giꜝ |
-| zoekt-webserver | 1 | - | 8 | - | 9Gꜝ | - | - |
-| minio | 1 | - | 1 | - | 500M | - | 1Giꜝ |
-| pgsql | 1 | - | 4 | - | 4G | - | - |
-| precise-code-intel | 1 | - | 2 | - | 4G | - | - |
-| searcher | 1 | - | 2 | - | 2G | - | 3Gꜝ |
-| symbols | 1 | - | 2 | - | 2Gꜝ | - | 2Gꜝ |
-| syntect-server | 1 | - | 4 | - | 6G | - | - |
-| worker | 1 | - | 2ꜝ | - | 4G | - | - |
+| sourcegraph-frontend-0 | 1 | - | 8 | - | 16g | - | - |
+| gitserver-0 | 1 | - | 4 | - | 8g | - | 36Gꜝ |
+| zoekt-indexserver-0 | 1 | - | 8 | - | 8gꜝ | - | 9Gꜝ |
+| zoekt-webserver-0 | 1 | - | 8 | - | 10gꜝ | - | 9Gꜝ |
+| minio | 1 | - | 1 | - | 0.5g | - | 1Gꜝ |
+| pgsql | 1 | - | 4 | - | 4g | - | - |
+| precise-code-intel-worker | 1 | - | 2 | - | 4g | - | - |
+| searcher-0 | 1 | - | 2 | - | 2g | - | 3Gꜝ |
+| symbols-0 | 1 | - | 2 | - | 2gꜝ | - | 2Gꜝ |
+| syntect-server | 1 | - | 4 | - | 6g | - | - |
+| worker | 1 | - | 2ꜝ | - | 4g | - | - |
 
 > ꜝ<small> This is a non-default value.</small>
 

--- a/internal/scaling/testdata/TestEstimate/default.golden
+++ b/internal/scaling/testdata/TestEstimate/default.golden
@@ -1,8 +1,11 @@
 `### Estimate summary
 
-* **Estimated total CPUs:** 35
-* **Estimated total memory:** 54g
-* **Note:** Use the default values for services or values not listed below .
+* **Estimated total CPUs:** 43
+* **Estimated total memory:** 68g
+* **Estimated total storage:** 1154g
+
+**Note:** The total estimated numbers shown above include default values for other services.
+Use the default values for services not listed below.
 * <details><summary>**IMPORTANT:** Cost-saving option to reduce resource consumption is available</summary><br><blockquote>
   <p>You may choose to use _shared resources_ to reduce the costs of your deployment:</p>
   <ul>
@@ -21,7 +24,7 @@
 | gitserver-0 | 1 | - | 4 | - | 8g | - | 36Gꜝ |
 | zoekt-indexserver-0 | 1 | - | 8 | - | 8gꜝ | - | 9Gꜝ |
 | zoekt-webserver-0 | 1 | - | 8 | - | 10gꜝ | - | 9Gꜝ |
-| minio | 1 | - | 1 | - | 0.5g | - | 1Gꜝ |
+| minio | 1 | - | 1 | - | 0.5gꜝ | - | 1Gꜝ |
 | pgsql | 1 | - | 4 | - | 4g | - | - |
 | precise-code-intel-worker | 1 | - | 2 | - | 4g | - | - |
 | searcher-0 | 1 | - | 2 | - | 2g | - | 26Gꜝ |

--- a/internal/scaling/testdata/TestEstimate/default.golden
+++ b/internal/scaling/testdata/TestEstimate/default.golden
@@ -1,13 +1,13 @@
 `### Estimate summary
 
-* **Estimated total CPUs:** 34
+* **Estimated total CPUs:** 35
 * **Estimated total memory:** 54g
-* **Note:** Use the default values for services not listed below .
+* **Note:** Use the default values for services or values not listed below .
 * <details><summary>**IMPORTANT:** Cost-saving option to reduce resource consumption is available</summary><br><blockquote>
   <p>You may choose to use _shared resources_ to reduce the costs of your deployment:</p>
   <ul>
   <li>**Estimated total _shared_ CPUs (shared):** 8</li>
-  <li>**Estimated total _shared_ memory (shared):** 9g</li>
+  <li>**Estimated total _shared_ memory (shared):** 10g</li>
   </ul><br>
   <p>**What this means:** Your instance would not have enough resources for all services to run _at peak load_, and _sometimes_ this could lead to a lack of resources. This may appear as searches being slow for some users if many other requests or indexing jobs are ongoing.</p>
   <p>On small instances such as what you've chosen, this can often be OK -- just keep an eye out for any performance issues and increase resources as needed.</p>
@@ -15,39 +15,21 @@
   </blockquote></details>
 
 
-| Service | Replicas | CPU requests | CPU limits | Memory requests | Memory limits |
-|---------|:----------:|:--------------:|:------------:|:-----------------:|:---------------:|
-| frontend | 2ꜝ | - | 4 | - | 8g |
-| gitserver | 1 | - | 4 | - | 8g |
-| pgsql | 1 | - | 4 | - | 4g |
-| precise-code-intel | 1 | - | 4ꜝ | - | 5gꜝ |
-| searcher | 1 | - | 2 | - | 2g |
-| symbols | 1 | - | 2 | - | 2gꜝ |
-| syntect-server | 1 | - | 4 | - | 6g |
-| worker | 1 | - | 2ꜝ | - | 4g |
-| zoekt-indexserver | 1 | - | 8 | - | 8gꜝ |
-| zoekt-webserver | 1 | - | 7ꜝ | - | 9gꜝ |
+| Service | Replica | CPU requests | CPU limits | MEM requests | MEM limits | Ephemeral Requests/Limits | Storage |
+|-------|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|
+| frontend | 2ꜝ | - | 4 | - | 8G | - | - |
+| gitserver | 1 | - | 4 | - | 8G | - | 36Giꜝ |
+| zoekt-indexserver | 1 | - | 8 | - | 8Gꜝ | - | 18Giꜝ |
+| zoekt-webserver | 1 | - | 8 | - | 9Gꜝ | - | - |
+| minio | 1 | - | 1 | - | 500M | - | 1Giꜝ |
+| pgsql | 1 | - | 4 | - | 4G | - | - |
+| precise-code-intel | 1 | - | 2 | - | 4G | - | - |
+| searcher | 1 | - | 2 | - | 2G | - | 3Gꜝ |
+| symbols | 1 | - | 2 | - | 2Gꜝ | - | 2Gꜝ |
+| syntect-server | 1 | - | 4 | - | 6G | - | - |
+| worker | 1 | - | 2ꜝ | - | 4G | - | - |
 
 > ꜝ<small> This is a non-default value.</small>
 
-### Storage
-
-| Service | Size | Note |
-|---------|:------------:|------|
-| codeinsights-db | 200GB | Starts at default as the value depends entirely on usage and the specific Insights that are being created by users. |
-| codeintel-db | 200GB | Starts at default as the value depends entirely on the size of indexes being uploaded. If Rockskip is enabled, 4 times the size of all repositories indexed by Rockskip is required. |
-| gitserver | 36GBꜝ | ~ 20 percent more than the total size of all repositories. |
-| minio | 1GB | ~ The size of the largest LSIF index file. |
-| pgsql | 200GB | Starts at default as the value grows depending on the number of active users and activity. |
-| indexed-search | 18GBꜝ | Approximately half of the total gitserver disk size. |
-> ꜝ<small> For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
-
-### Ephemeral storage
-
-| Service | Limits | Note |
-|---------|:------------:|------|
-| searcher| 3.00GBꜝ | ~ Total number of average repositories divided by 100. |
-| symbols | 2GBꜝ | ~ 20 percent more than the size of your largest repository. Using an SSD is highly preferred if you are not indexing with Rockskip. |
-> ꜝ<small> For Kubernetes deployments, set the resources.ephemeral-storage size equal to this value divided by the number of replicas.</small>
 
 `

--- a/internal/scaling/testdata/TestEstimate/default.golden
+++ b/internal/scaling/testdata/TestEstimate/default.golden
@@ -1,13 +1,13 @@
 `### Estimate summary
 
-* **Estimated total CPUs:** 37
-* **Estimated total memory:** 57g
+* **Estimated total CPUs:** 34
+* **Estimated total memory:** 54g
 * **Note:** Use the default values for services not listed below .
 * <details><summary>**IMPORTANT:** Cost-saving option to reduce resource consumption is available</summary><br><blockquote>
   <p>You may choose to use _shared resources_ to reduce the costs of your deployment:</p>
   <ul>
   <li>**Estimated total _shared_ CPUs (shared):** 8</li>
-  <li>**Estimated total _shared_ memory (shared):** 10g</li>
+  <li>**Estimated total _shared_ memory (shared):** 9g</li>
   </ul><br>
   <p>**What this means:** Your instance would not have enough resources for all services to run _at peak load_, and _sometimes_ this could lead to a lack of resources. This may appear as searches being slow for some users if many other requests or indexing jobs are ongoing.</p>
   <p>On small instances such as what you've chosen, this can often be OK -- just keep an eye out for any performance issues and increase resources as needed.</p>
@@ -20,13 +20,13 @@
 | frontend | 2ꜝ | - | 4 | - | 8g |
 | gitserver | 1 | - | 4 | - | 8g |
 | pgsql | 1 | - | 4 | - | 4g |
-| precise-code-intel | 1 | - | 4ꜝ | - | 6gꜝ |
+| precise-code-intel | 1 | - | 4ꜝ | - | 5gꜝ |
 | searcher | 1 | - | 2 | - | 2g |
 | symbols | 1 | - | 2 | - | 2gꜝ |
 | syntect-server | 1 | - | 4 | - | 6g |
 | worker | 1 | - | 2ꜝ | - | 4g |
 | zoekt-indexserver | 1 | - | 8 | - | 8gꜝ |
-| zoekt-webserver | 1 | - | 8 | - | 10gꜝ |
+| zoekt-webserver | 1 | - | 7ꜝ | - | 9gꜝ |
 
 > ꜝ<small> This is a non-default value.</small>
 
@@ -40,7 +40,7 @@
 | minio | 1GB | ~ The size of the largest LSIF index file. |
 | pgsql | 200GB | Starts at default as the value grows depending on the number of active users and activity. |
 | indexed-search | 18GBꜝ | Approximately half of the total gitserver disk size. |
-> ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
+> ꜝ<small> For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
 
 ### Ephemeral storage
 
@@ -48,6 +48,6 @@
 |---------|:------------:|------|
 | searcher| 3.00GBꜝ | ~ Total number of average repositories divided by 100. |
 | symbols | 2GBꜝ | ~ 20 percent more than the size of your largest repository. Using an SSD is highly preferred if you are not indexing with Rockskip. |
-> ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
+> ꜝ<small> For Kubernetes deployments, set the resources.ephemeral-storage size equal to this value divided by the number of replicas.</small>
 
 `

--- a/internal/scaling/testdata/TestEstimate/default.golden
+++ b/internal/scaling/testdata/TestEstimate/default.golden
@@ -4,8 +4,7 @@
 * **Estimated total memory:** 62g
 * **Estimated total storage:** 898g
 
-**Note:** The total estimated numbers shown above include default values for other services.
-Use the default values for services not listed below.
+<small>**Note:** The estimated total includes default values for other services.</small>
 * <details><summary>**IMPORTANT:** Cost-saving option to reduce resource consumption is available</summary><br><blockquote>
   <p>You may choose to use _shared resources_ to reduce the costs of your deployment:</p>
   <ul>

--- a/internal/scaling/testdata/TestEstimate/default.golden
+++ b/internal/scaling/testdata/TestEstimate/default.golden
@@ -24,8 +24,8 @@
 | minio | 1 | - | 1 | - | 0.5g | - | 1Gꜝ |
 | pgsql | 1 | - | 4 | - | 4g | - | - |
 | precise-code-intel-worker | 1 | - | 2 | - | 4g | - | - |
-| searcher-0 | 1 | - | 2 | - | 2g | - | 3Gꜝ |
-| symbols-0 | 1 | - | 2 | - | 2gꜝ | - | 2Gꜝ |
+| searcher-0 | 1 | - | 2 | - | 2g | - | 26Gꜝ |
+| symbols-0 | 1 | - | 2 | - | 2gꜝ | - | 3Gꜝ |
 | syntect-server | 1 | - | 4 | - | 6g | - | - |
 | worker | 1 | - | 2ꜝ | - | 4g | - | - |
 

--- a/internal/scaling/testdata/TestEstimate/default.golden
+++ b/internal/scaling/testdata/TestEstimate/default.golden
@@ -1,8 +1,8 @@
 `### Estimate summary
 
-* **Estimated total CPUs:** 43
-* **Estimated total memory:** 68g
-* **Estimated total storage:** 1154g
+* **Estimated total CPUs:** 41
+* **Estimated total memory:** 62g
+* **Estimated total storage:** 898g
 
 **Note:** The total estimated numbers shown above include default values for other services.
 Use the default values for services not listed below.
@@ -18,19 +18,21 @@ Use the default values for services not listed below.
   </blockquote></details>
 
 
-| Service | Replica | CPU requests | CPU limits | MEM requests | MEM limits | Ephemeral Requests/Limits | Storage |
-|-------|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|
-| sourcegraph-frontend-0 | 1 | - | 8 | - | 16g | - | - |
-| gitserver-0 | 1 | - | 4 | - | 8g | - | 36Gꜝ |
-| zoekt-indexserver-0 | 1 | - | 8 | - | 8gꜝ | - | 9Gꜝ |
-| zoekt-webserver-0 | 1 | - | 8 | - | 10gꜝ | - | 9Gꜝ |
-| minio | 1 | - | 1 | - | 0.5gꜝ | - | 1Gꜝ |
-| pgsql | 1 | - | 4 | - | 4g | - | - |
-| precise-code-intel-worker | 1 | - | 2 | - | 4g | - | - |
-| searcher-0 | 1 | - | 2 | - | 2g | - | 26Gꜝ |
-| symbols-0 | 1 | - | 2 | - | 2gꜝ | - | 3Gꜝ |
-| syntect-server | 1 | - | 4 | - | 6g | - | - |
-| worker | 1 | - | 2ꜝ | - | 4g | - | - |
+| Service | Replica | CPU requests | CPU limits | MEM requests | MEM limits | EPH requests | EPH limits | Storage |
+|-------|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|
+| sourcegraph-frontend-0 | 1 | - | 6ꜝ | - | 12gꜝ | - | - | - |
+| gitserver-0 | 1 | - | 4 | - | 8g | - | - | 36Gꜝ |
+| zoekt-indexserver-0 | 1 | - | 8 | - | 8gꜝ | - | - | 9Gꜝ |
+| zoekt-webserver-0 | 1 | - | 5ꜝ | - | 10gꜝ | - | - | 9Gꜝ |
+| minio | 1 | - | 1 | - | 0.5gꜝ | - | - | 1Gꜝ |
+| pgsql | 1 | - | 4 | - | 4g | - | - | - |
+| precise-code-intel-worker | 1 | - | 2 | - | 4g | - | - | - |
+| redis-cache | 1 | - | 1 | - | 1gꜝ | - | - | - |
+| redis-store | 1 | - | 1 | - | 2gꜝ | - | - | - |
+| searcher-0 | 1 | - | 2 | - | 2g | - | - | 5Gꜝ |
+| symbols-0 | 1 | - | 2 | - | 2gꜝ | - | - | 3Gꜝ |
+| syntect-server | 1 | - | 4 | - | 6g | - | - | - |
+| worker | 1 | - | 2ꜝ | - | 4g | - | - | - |
 
 > ꜝ<small> This is a non-default value.</small>
 

--- a/internal/scaling/testdata/TestEstimate/monorepo.golden
+++ b/internal/scaling/testdata/TestEstimate/monorepo.golden
@@ -1,7 +1,7 @@
 `### Estimate summary
 
-* **Estimated total CPUs:** 37
-* **Estimated total memory:** 61g
+* **Estimated total CPUs:** 34
+* **Estimated total memory:** 59g
 * **Note:** Use the default values for services not listed below .
 * <details><summary>**IMPORTANT:** Cost-saving option to reduce resource consumption is available</summary><br><blockquote>
   <p>You may choose to use _shared resources_ to reduce the costs of your deployment:</p>
@@ -20,13 +20,13 @@
 | frontend | 2ꜝ | - | 4 | - | 8g |
 | gitserver | 1 | - | 4 | - | 8g |
 | pgsql | 1 | - | 4 | - | 4g |
-| precise-code-intel | 1 | - | 4ꜝ | - | 6gꜝ |
+| precise-code-intel | 1 | - | 4ꜝ | - | 5gꜝ |
 | searcher | 1 | - | 2 | - | 2g |
-| symbols | 1 | - | 3ꜝ | - | 5gꜝ |
+| symbols | 1 | - | 2 | - | 3gꜝ |
 | syntect-server | 1 | - | 4 | - | 6g |
 | worker | 1 | - | 2ꜝ | - | 4g |
 | zoekt-indexserver | 1 | - | 8 | - | 12gꜝ |
-| zoekt-webserver | 1 | - | 8 | - | 8gꜝ |
+| zoekt-webserver | 1 | - | 7ꜝ | - | 8gꜝ |
 
 > ꜝ<small> This is a non-default value.</small>
 
@@ -40,7 +40,7 @@
 | minio | 1GB | ~ The size of the largest LSIF index file. |
 | pgsql | 200GB | Starts at default as the value grows depending on the number of active users and activity. |
 | indexed-search | 18GBꜝ | Approximately half of the total gitserver disk size. |
-> ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
+> ꜝ<small> For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
 
 ### Ephemeral storage
 
@@ -48,6 +48,6 @@
 |---------|:------------:|------|
 | searcher| 0.00GBꜝ | ~ Total number of average repositories divided by 100. |
 | symbols | 2GBꜝ | ~ 20 percent more than the size of your largest repository. Using an SSD is highly preferred if you are not indexing with Rockskip. |
-> ꜝ<small> This value represents the total disk space required for the service. For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
+> ꜝ<small> For Kubernetes deployments, set the resources.ephemeral-storage size equal to this value divided by the number of replicas.</small>
 
 `

--- a/internal/scaling/testdata/TestEstimate/monorepo.golden
+++ b/internal/scaling/testdata/TestEstimate/monorepo.golden
@@ -24,8 +24,8 @@
 | minio | 1 | - | 1 | - | 0.5g | - | 1Gꜝ |
 | pgsql | 1 | - | 4 | - | 4g | - | - |
 | precise-code-intel-worker | 1 | - | 2 | - | 4g | - | - |
-| searcher-0 | 1 | - | 2 | - | 2g | - | - |
-| symbols-0 | 1 | - | 2 | - | 3gꜝ | - | 2Gꜝ |
+| searcher-0 | 1 | - | 2 | - | 2g | - | 26Gꜝ |
+| symbols-0 | 1 | - | 2 | - | 3gꜝ | - | 3Gꜝ |
 | syntect-server | 1 | - | 4 | - | 6g | - | - |
 | worker | 1 | - | 2ꜝ | - | 4g | - | - |
 

--- a/internal/scaling/testdata/TestEstimate/monorepo.golden
+++ b/internal/scaling/testdata/TestEstimate/monorepo.golden
@@ -17,17 +17,17 @@
 
 | Service | Replica | CPU requests | CPU limits | MEM requests | MEM limits | Ephemeral Requests/Limits | Storage |
 |-------|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|
-| frontend | 2ꜝ | - | 4 | - | 8G | - | - |
-| gitserver | 1 | - | 4 | - | 8G | - | 36Giꜝ |
-| zoekt-indexserver | 1 | - | 8 | - | 12Gꜝ | - | 18Giꜝ |
-| zoekt-webserver | 1 | - | 8 | - | 8Gꜝ | - | - |
-| minio | 1 | - | 1 | - | 500M | - | 1Giꜝ |
-| pgsql | 1 | - | 4 | - | 4G | - | - |
-| precise-code-intel | 1 | - | 2 | - | 4G | - | - |
-| searcher | 1 | - | 2 | - | 2G | - | - |
-| symbols | 1 | - | 2 | - | 3Gꜝ | - | 2Gꜝ |
-| syntect-server | 1 | - | 4 | - | 6G | - | - |
-| worker | 1 | - | 2ꜝ | - | 4G | - | - |
+| sourcegraph-frontend-0 | 1 | - | 8 | - | 16g | - | - |
+| gitserver-0 | 1 | - | 4 | - | 8g | - | 36Gꜝ |
+| zoekt-indexserver-0 | 1 | - | 8 | - | 12gꜝ | - | 9Gꜝ |
+| zoekt-webserver-0 | 1 | - | 8 | - | 8gꜝ | - | 9Gꜝ |
+| minio | 1 | - | 1 | - | 0.5g | - | 1Gꜝ |
+| pgsql | 1 | - | 4 | - | 4g | - | - |
+| precise-code-intel-worker | 1 | - | 2 | - | 4g | - | - |
+| searcher-0 | 1 | - | 2 | - | 2g | - | - |
+| symbols-0 | 1 | - | 2 | - | 3gꜝ | - | 2Gꜝ |
+| syntect-server | 1 | - | 4 | - | 6g | - | - |
+| worker | 1 | - | 2ꜝ | - | 4g | - | - |
 
 > ꜝ<small> This is a non-default value.</small>
 

--- a/internal/scaling/testdata/TestEstimate/monorepo.golden
+++ b/internal/scaling/testdata/TestEstimate/monorepo.golden
@@ -1,8 +1,8 @@
 `### Estimate summary
 
-* **Estimated total CPUs:** 34
-* **Estimated total memory:** 59g
-* **Note:** Use the default values for services not listed below .
+* **Estimated total CPUs:** 35
+* **Estimated total memory:** 57g
+* **Note:** Use the default values for services or values not listed below .
 * <details><summary>**IMPORTANT:** Cost-saving option to reduce resource consumption is available</summary><br><blockquote>
   <p>You may choose to use _shared resources_ to reduce the costs of your deployment:</p>
   <ul>
@@ -15,39 +15,21 @@
   </blockquote></details>
 
 
-| Service | Replicas | CPU requests | CPU limits | Memory requests | Memory limits |
-|---------|:----------:|:--------------:|:------------:|:-----------------:|:---------------:|
-| frontend | 2ꜝ | - | 4 | - | 8g |
-| gitserver | 1 | - | 4 | - | 8g |
-| pgsql | 1 | - | 4 | - | 4g |
-| precise-code-intel | 1 | - | 4ꜝ | - | 5gꜝ |
-| searcher | 1 | - | 2 | - | 2g |
-| symbols | 1 | - | 2 | - | 3gꜝ |
-| syntect-server | 1 | - | 4 | - | 6g |
-| worker | 1 | - | 2ꜝ | - | 4g |
-| zoekt-indexserver | 1 | - | 8 | - | 12gꜝ |
-| zoekt-webserver | 1 | - | 7ꜝ | - | 8gꜝ |
+| Service | Replica | CPU requests | CPU limits | MEM requests | MEM limits | Ephemeral Requests/Limits | Storage |
+|-------|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|
+| frontend | 2ꜝ | - | 4 | - | 8G | - | - |
+| gitserver | 1 | - | 4 | - | 8G | - | 36Giꜝ |
+| zoekt-indexserver | 1 | - | 8 | - | 12Gꜝ | - | 18Giꜝ |
+| zoekt-webserver | 1 | - | 8 | - | 8Gꜝ | - | - |
+| minio | 1 | - | 1 | - | 500M | - | 1Giꜝ |
+| pgsql | 1 | - | 4 | - | 4G | - | - |
+| precise-code-intel | 1 | - | 2 | - | 4G | - | - |
+| searcher | 1 | - | 2 | - | 2G | - | - |
+| symbols | 1 | - | 2 | - | 3Gꜝ | - | 2Gꜝ |
+| syntect-server | 1 | - | 4 | - | 6G | - | - |
+| worker | 1 | - | 2ꜝ | - | 4G | - | - |
 
 > ꜝ<small> This is a non-default value.</small>
 
-### Storage
-
-| Service | Size | Note |
-|---------|:------------:|------|
-| codeinsights-db | 200GB | Starts at default as the value depends entirely on usage and the specific Insights that are being created by users. |
-| codeintel-db | 200GB | Starts at default as the value depends entirely on the size of indexes being uploaded. If Rockskip is enabled, 4 times the size of all repositories indexed by Rockskip is required. |
-| gitserver | 36GBꜝ | ~ 20 percent more than the total size of all repositories. |
-| minio | 1GB | ~ The size of the largest LSIF index file. |
-| pgsql | 200GB | Starts at default as the value grows depending on the number of active users and activity. |
-| indexed-search | 18GBꜝ | Approximately half of the total gitserver disk size. |
-> ꜝ<small> For Kubernetes deployments, set the PVC storage size equal to this value divided by the number of replicas. </small>
-
-### Ephemeral storage
-
-| Service | Limits | Note |
-|---------|:------------:|------|
-| searcher| 0.00GBꜝ | ~ Total number of average repositories divided by 100. |
-| symbols | 2GBꜝ | ~ 20 percent more than the size of your largest repository. Using an SSD is highly preferred if you are not indexing with Rockskip. |
-> ꜝ<small> For Kubernetes deployments, set the resources.ephemeral-storage size equal to this value divided by the number of replicas.</small>
 
 `

--- a/internal/scaling/testdata/TestEstimate/monorepo.golden
+++ b/internal/scaling/testdata/TestEstimate/monorepo.golden
@@ -4,8 +4,7 @@
 * **Estimated total memory:** 64g
 * **Estimated total storage:** 898g
 
-**Note:** The total estimated numbers shown above include default values for other services.
-Use the default values for services not listed below.
+<small>**Note:** The estimated total includes default values for other services.</small>
 * <details><summary>**IMPORTANT:** Cost-saving option to reduce resource consumption is available</summary><br><blockquote>
   <p>You may choose to use _shared resources_ to reduce the costs of your deployment:</p>
   <ul>

--- a/internal/scaling/testdata/TestEstimate/monorepo.golden
+++ b/internal/scaling/testdata/TestEstimate/monorepo.golden
@@ -1,8 +1,8 @@
 `### Estimate summary
 
-* **Estimated total CPUs:** 43
-* **Estimated total memory:** 70g
-* **Estimated total storage:** 1154g
+* **Estimated total CPUs:** 41
+* **Estimated total memory:** 64g
+* **Estimated total storage:** 898g
 
 **Note:** The total estimated numbers shown above include default values for other services.
 Use the default values for services not listed below.
@@ -18,19 +18,21 @@ Use the default values for services not listed below.
   </blockquote></details>
 
 
-| Service | Replica | CPU requests | CPU limits | MEM requests | MEM limits | Ephemeral Requests/Limits | Storage |
-|-------|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|
-| sourcegraph-frontend-0 | 1 | - | 8 | - | 16g | - | - |
-| gitserver-0 | 1 | - | 4 | - | 8g | - | 36Gꜝ |
-| zoekt-indexserver-0 | 1 | - | 8 | - | 12gꜝ | - | 9Gꜝ |
-| zoekt-webserver-0 | 1 | - | 8 | - | 8gꜝ | - | 9Gꜝ |
-| minio | 1 | - | 1 | - | 0.5gꜝ | - | 1Gꜝ |
-| pgsql | 1 | - | 4 | - | 4g | - | - |
-| precise-code-intel-worker | 1 | - | 2 | - | 4g | - | - |
-| searcher-0 | 1 | - | 2 | - | 2g | - | 26Gꜝ |
-| symbols-0 | 1 | - | 2 | - | 3gꜝ | - | 3Gꜝ |
-| syntect-server | 1 | - | 4 | - | 6g | - | - |
-| worker | 1 | - | 2ꜝ | - | 4g | - | - |
+| Service | Replica | CPU requests | CPU limits | MEM requests | MEM limits | EPH requests | EPH limits | Storage |
+|-------|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|
+| sourcegraph-frontend-0 | 1 | - | 6ꜝ | - | 12gꜝ | - | - | - |
+| gitserver-0 | 1 | - | 4 | - | 8g | - | - | 36Gꜝ |
+| zoekt-indexserver-0 | 1 | - | 8 | - | 12gꜝ | - | - | 9Gꜝ |
+| zoekt-webserver-0 | 1 | - | 5ꜝ | - | 8gꜝ | - | - | 9Gꜝ |
+| minio | 1 | - | 1 | - | 0.5gꜝ | - | - | 1Gꜝ |
+| pgsql | 1 | - | 4 | - | 4g | - | - | - |
+| precise-code-intel-worker | 1 | - | 2 | - | 4g | - | - | - |
+| redis-cache | 1 | - | 1 | - | 1gꜝ | - | - | - |
+| redis-store | 1 | - | 1 | - | 2gꜝ | - | - | - |
+| searcher-0 | 1 | - | 2 | - | 2g | - | - | 2Gꜝ |
+| symbols-0 | 1 | - | 2 | - | 2gꜝ | - | - | 3Gꜝ |
+| syntect-server | 1 | - | 4 | - | 6g | - | - | - |
+| worker | 1 | - | 2ꜝ | - | 4g | - | - | - |
 
 > ꜝ<small> This is a non-default value.</small>
 

--- a/internal/scaling/testdata/TestEstimate/monorepo.golden
+++ b/internal/scaling/testdata/TestEstimate/monorepo.golden
@@ -1,8 +1,11 @@
 `### Estimate summary
 
-* **Estimated total CPUs:** 35
-* **Estimated total memory:** 56g
-* **Note:** Use the default values for services or values not listed below .
+* **Estimated total CPUs:** 43
+* **Estimated total memory:** 70g
+* **Estimated total storage:** 1154g
+
+**Note:** The total estimated numbers shown above include default values for other services.
+Use the default values for services not listed below.
 * <details><summary>**IMPORTANT:** Cost-saving option to reduce resource consumption is available</summary><br><blockquote>
   <p>You may choose to use _shared resources_ to reduce the costs of your deployment:</p>
   <ul>
@@ -21,7 +24,7 @@
 | gitserver-0 | 1 | - | 4 | - | 8g | - | 36Gꜝ |
 | zoekt-indexserver-0 | 1 | - | 8 | - | 12gꜝ | - | 9Gꜝ |
 | zoekt-webserver-0 | 1 | - | 8 | - | 8gꜝ | - | 9Gꜝ |
-| minio | 1 | - | 1 | - | 0.5g | - | 1Gꜝ |
+| minio | 1 | - | 1 | - | 0.5gꜝ | - | 1Gꜝ |
 | pgsql | 1 | - | 4 | - | 4g | - | - |
 | precise-code-intel-worker | 1 | - | 2 | - | 4g | - | - |
 | searcher-0 | 1 | - | 2 | - | 2g | - | 26Gꜝ |

--- a/internal/scaling/testdata/TestEstimate/monorepo.golden
+++ b/internal/scaling/testdata/TestEstimate/monorepo.golden
@@ -1,7 +1,7 @@
 `### Estimate summary
 
 * **Estimated total CPUs:** 35
-* **Estimated total memory:** 57g
+* **Estimated total memory:** 56g
 * **Note:** Use the default values for services or values not listed below .
 * <details><summary>**IMPORTANT:** Cost-saving option to reduce resource consumption is available</summary><br><blockquote>
   <p>You may choose to use _shared resources_ to reduce the costs of your deployment:</p>

--- a/scaling.go
+++ b/scaling.go
@@ -172,19 +172,40 @@ func (p *MainView) Render() vecty.ComponentOrHTML {
 		Users:            p.users,
 		EngagementRate:   p.engagementRate,
 		CodeInsight:      p.codeinsightEabled,
-	}).Calculate().Result()
+	}).Calculate()
+
+	markdownContent := estimate.Result()
+	jsonContent := estimate.Json()
 
 	return elem.Form(
 		vecty.Markup(vecty.Class("estimator")),
 		p.inputs(),
-		&markdown{Content: estimate},
+		&markdown{Content: markdownContent},
 		elem.Heading3(vecty.Text("Export result")),
+		elem.Details(
+			elem.Summary(vecty.Text("Export as Helm")),
+			elem.Break(),
+			elem.TextArea(
+				vecty.Markup(vecty.Class("copy-as-markdown")),
+				vecty.Text(string(jsonContent)),
+			),
+			elem.Paragraph(
+				elem.Strong(vecty.Text("Export as Helm ")),
+				elem.Anchor(
+					vecty.Markup(
+						vecty.Markup(prop.Href("data:text/csv;charset=utf-8,"+jsonContent)),
+						vecty.Property("download", "sg_resources_estimate_helm.yaml"),
+					),
+					vecty.Text("Click to download"),
+				),
+			),
+		),
 		elem.Details(
 			elem.Summary(vecty.Text("Export as Markdown")),
 			elem.Break(),
 			elem.TextArea(
 				vecty.Markup(vecty.Class("copy-as-markdown")),
-				vecty.Text(string(estimate)),
+				vecty.Text(string(markdownContent)),
 			),
 		),
 		elem.Break(),

--- a/scaling.go
+++ b/scaling.go
@@ -174,7 +174,7 @@ func (p *MainView) Render() vecty.ComponentOrHTML {
 		CodeInsight:      p.codeinsightEabled,
 	}).Calculate()
 
-	markdownContent := estimate.Result()
+	markdownContent := estimate.MarkdownExport()
 	helmContent := estimate.HelmExport()
 	dockerContent := estimate.DockerExport()
 

--- a/scaling.go
+++ b/scaling.go
@@ -20,11 +20,11 @@ func main() {
 		deploymentType:    "type",
 		users:             300,
 		engagementRate:    100,
-		repositories:      5000,
-		reposize:          500,
-		largeMonorepos:    5,
+		repositories:      3000,
+		reposize:          100,
+		largeMonorepos:    2,
 		largestRepoSize:   5,
-		largestIndexSize:  3,
+		largestIndexSize:  0,
 		codeinsightEabled: "Enable",
 	})
 	if err != nil {
@@ -184,7 +184,7 @@ func (p *MainView) Render() vecty.ComponentOrHTML {
 		&markdown{Content: markdownContent},
 		elem.Heading3(vecty.Text("Export result")),
 		elem.Details(
-			elem.Summary(vecty.Text("Export as Helm Override File")),
+			elem.Summary(vecty.Text("Export as Helm Override File (Beta)")),
 			elem.Break(),
 			elem.TextArea(
 				vecty.Markup(vecty.Class("copy-as-markdown")),
@@ -202,7 +202,7 @@ func (p *MainView) Render() vecty.ComponentOrHTML {
 			),
 		),
 		elem.Details(
-			elem.Summary(vecty.Text("Export as Docker Compose Override File")),
+			elem.Summary(vecty.Text("Export as Docker Compose Override File (Beta)")),
 			elem.Break(),
 			elem.TextArea(
 				vecty.Markup(vecty.Class("copy-as-markdown")),

--- a/scaling.go
+++ b/scaling.go
@@ -175,8 +175,8 @@ func (p *MainView) Render() vecty.ComponentOrHTML {
 	}).Calculate()
 
 	markdownContent := estimate.Result()
-
 	helmContent := estimate.HelmExport()
+	dockerContent := estimate.DockerExport()
 
 	return elem.Form(
 		vecty.Markup(vecty.Class("estimator")),
@@ -184,20 +184,38 @@ func (p *MainView) Render() vecty.ComponentOrHTML {
 		&markdown{Content: markdownContent},
 		elem.Heading3(vecty.Text("Export result")),
 		elem.Details(
-			elem.Summary(vecty.Text("Export as Helm")),
+			elem.Summary(vecty.Text("Export as Helm Override File")),
 			elem.Break(),
 			elem.TextArea(
 				vecty.Markup(vecty.Class("copy-as-markdown")),
-				vecty.Text(string(helmContent)),
+				vecty.Text(helmContent),
 			),
 			elem.Paragraph(
-				elem.Strong(vecty.Text("Helm Override File -- ")),
+				elem.Strong(vecty.Text("Click to Download: ")),
 				elem.Anchor(
 					vecty.Markup(
 						vecty.Markup(prop.Href("data:text/csv;charset=utf-8,"+helmContent)),
 						vecty.Property("download", "override.yaml"),
 					),
-					vecty.Text("Click to download"),
+					vecty.Text("override.yaml"),
+				),
+			),
+		),
+		elem.Details(
+			elem.Summary(vecty.Text("Export as Docker Compose Override File")),
+			elem.Break(),
+			elem.TextArea(
+				vecty.Markup(vecty.Class("copy-as-markdown")),
+				vecty.Text(dockerContent),
+			),
+			elem.Paragraph(
+				elem.Strong(vecty.Text("Click to Download: ")),
+				elem.Anchor(
+					vecty.Markup(
+						vecty.Markup(prop.Href("data:text/csv;charset=utf-8,"+dockerContent)),
+						vecty.Property("download", "docker-compose.override.yaml"),
+					),
+					vecty.Text("docker-compose.override.yaml"),
 				),
 			),
 		),

--- a/scaling.go
+++ b/scaling.go
@@ -175,7 +175,8 @@ func (p *MainView) Render() vecty.ComponentOrHTML {
 	}).Calculate()
 
 	markdownContent := estimate.Result()
-	jsonContent := estimate.Json()
+
+	helmContent := estimate.HelmExport()
 
 	return elem.Form(
 		vecty.Markup(vecty.Class("estimator")),
@@ -187,14 +188,14 @@ func (p *MainView) Render() vecty.ComponentOrHTML {
 			elem.Break(),
 			elem.TextArea(
 				vecty.Markup(vecty.Class("copy-as-markdown")),
-				vecty.Text(string(jsonContent)),
+				vecty.Text(string(helmContent)),
 			),
 			elem.Paragraph(
-				elem.Strong(vecty.Text("Export as Helm ")),
+				elem.Strong(vecty.Text("Helm Override File -- ")),
 				elem.Anchor(
 					vecty.Markup(
-						vecty.Markup(prop.Href("data:text/csv;charset=utf-8,"+jsonContent)),
-						vecty.Property("download", "sg_resources_estimate_helm.yaml"),
+						vecty.Markup(prop.Href("data:text/csv;charset=utf-8,"+helmContent)),
+						vecty.Property("download", "override.yaml"),
 					),
 					vecty.Text("Click to download"),
 				),


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/38320

This PR adds:
- a new feature to export the estimated result as override yaml file for Helm
- a new feature to export the estimated result as override yaml file for Docker Compose
- estimated total storage
- display pod name for services in k8s 


## Screenshots

### Docker-Compose:
![image](https://user-images.githubusercontent.com/68532117/178614169-f3c2538a-4910-449a-a2a4-247bd7021fbc.png)


![image](https://user-images.githubusercontent.com/68532117/177612353-1be59c74-fab7-42bb-8e0a-471000fd5a8c.png)

### Helm / K8s:
![image](https://user-images.githubusercontent.com/68532117/178614132-8f81fb45-9421-4b38-b9c8-7c99ce0e8257.png)

![image](https://user-images.githubusercontent.com/68532117/177612397-b9c57d1f-8235-4c1e-8799-6ed577d1aef5.png)



## Example output files

### Docker-Compose:
```yaml
services:
  gitserver-0:
    cpus: '16'
    mem_limit: '32g'
  minio:
    cpus: '1'
    mem_limit: '500m'
  pgsql:
    cpus: '4'
    mem_limit: '8g'
  precise-code-intel-worker:
    cpus: '1'
    mem_limit: '8g'
  searcher-0:
    cpus: '750m'
    mem_limit: '4g'
  sourcegraph-frontend-0:
    cpus: '6'
    mem_limit: '27g'
  symbols-0:
    cpus: '4'
    mem_limit: '18g'
  syntect-server:
    cpus: '500m'
    mem_limit: '6g'
  worker:
    cpus: '750m'
    mem_limit: '5g'
  zoekt-indexserver-0:
    cpus: '4'
    mem_limit: '16g'
  zoekt-webserver-0:
    cpus: '4'
    mem_limit: '35g'
version: '2.4'
```


### Helm:
```yaml
frontend:
  replicaCount: 3
  resources:
    limits:
      cpu: '4'
      memory: 9G
    requests:
      cpu: '2'
      memory: 4G
gitserver:
  replicaCount: 2
  resources:
    limits:
      cpu: '8'
      memory: 16G
    requests:
      cpu: '8'
      memory: 16G
  storageSize: 300Gi
indexedSearch:
  replicaCount: 1
  resources:
    limits:
      cpu: '8'
      memory: 16G
    requests:
      cpu: '4'
      memory: 8G
  storageSize: 300Gi
indexedSearchIndexer:
  replicaCount: 1
  resources:
    limits:
      cpu: '8'
      memory: 35G
    requests:
      cpu: '4'
      memory: 18G
minio:
  replicaCount: 1
  resources:
    limits:
      cpu: '1'
      memory: 500M
    requests:
      cpu: '1'
      memory: 500M
  storageSize: 3Gi
pgsql:
  replicaCount: 1
  resources:
    limits:
      cpu: '4'
      memory: 8G
    requests:
      cpu: '4'
      memory: 8G
preciseCodeIntel:
  replicaCount: 1
  resources:
    limits:
      cpu: '3'
      memory: 8G
    requests:
      cpu: '1'
      memory: 4G
searcher:
  replicaCount: 1
  resources:
    limits:
      cpu: '2'
      ephemeral-storage: 39G
      memory: 4G
    requests:
      cpu: 750M
      ephemeral-storage: 37G
      memory: 2G
symbols:
  replicaCount: 2
  resources:
    limits:
      cpu: '4'
      ephemeral-storage: 3G
      memory: 9G
    requests:
      cpu: '2'
      ephemeral-storage: 2G
      memory: 5G
syntectServer:
  replicaCount: 1
  resources:
    limits:
      cpu: '4'
      memory: 6G
    requests:
      cpu: 500M
      memory: 2G
worker:
  replicaCount: 1
  resources:
    limits:
      cpu: '2'
      memory: 5G
    requests:
      cpu: 750M
      memory: 2G
```

## Limitations

override file for docker-compose does not include options to override storage size, and it only supports 1 replica per service