### PR TITLE
Fix 404 link, add prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ This tool ensures you provision appropriate resources to scale your instance.
 
 ## Development Prerequisites
 
-- [Install Go](https://golang.org/doc/install), then:
+- [Install Go](https://golang.org/doc/install)
+- [Install WasmServe](https://github.com/hajimehoshi/wasmserve)
 
 ### Optional prerequisites
 
-The project includes a [justfile](https://github.com/sourcegraph/infrastructure/blob/main/justfile) that includes simple
+The project includes a [justfile](https://github.com/sourcegraph/resource-estimator/blob/main/justfile) that includes simple
 commands for automating common tasks such as:
 
 - Building the WASM binary: `just build`


### PR DESCRIPTION
- I've fixed the link to the justfile (the one in `infrastructure` doesn't exist anymore)
- I _think_ one also needs to install WasmServe, so I've added it as a prerequisite.

But to be honest, I'm not sure about this second one because I understand `watch-wasm.sh` also gets it. However, I just couldn't run the whole thing. `just watch` runs, but in the browser, I'm getting `exit status 1`, and in the console, this:

```
go: creating new go.mod: module foo
go: .: no package to get in current directory
```

So I couldn't get started with it after all.
Maybe this PR could be used to further improve the docs to allow someone to actually set this up, or perhaps I could create an issue for this?

Why I tried this all: I wanted to fix this https://github.com/sourcegraph/sourcegraph/issues/35896 on the docs site.

# Test plan

Discuss the above questions.