### PR TITLE
Update: Add blobstore and instance size, remove minio

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/sourcegraph/resource-estimator
 go 1.18
 
 require (
-	github.com/hajimehoshi/wasmserve v0.0.0-20220920031344-5307a095c2aa
+	github.com/hajimehoshi/wasmserve v0.0.0-20221128151022-689d7ac772c6
 	github.com/hexops/autogold v1.3.0
 	github.com/hexops/vecty v0.6.0
 	github.com/microcosm-cc/bluemonday v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/hajimehoshi/wasmserve v0.0.0-20220407032727-829ff31b29cd h1:ZPD+Q72Uu
 github.com/hajimehoshi/wasmserve v0.0.0-20220407032727-829ff31b29cd/go.mod h1:R7GWZ4rfKerxj6MG5yspAk5BEI7j0IgeIQqncBraNRg=
 github.com/hajimehoshi/wasmserve v0.0.0-20220920031344-5307a095c2aa h1:x7QoFaUjWg1TpZR9rwrZcahOCw6rSKYy444uJyn1wCs=
 github.com/hajimehoshi/wasmserve v0.0.0-20220920031344-5307a095c2aa/go.mod h1:R7GWZ4rfKerxj6MG5yspAk5BEI7j0IgeIQqncBraNRg=
+github.com/hajimehoshi/wasmserve v0.0.0-20221128151022-689d7ac772c6 h1:mt245kCFCBtpmDv715XGr/1lb8xAKWFeh9lzyUN03Gw=
+github.com/hajimehoshi/wasmserve v0.0.0-20221128151022-689d7ac772c6/go.mod h1:R7GWZ4rfKerxj6MG5yspAk5BEI7j0IgeIQqncBraNRg=
 github.com/hexops/autogold v0.8.1/go.mod h1:97HLDXyG23akzAoRYJh/2OBs3kd80eHyKPvZw0S5ZBY=
 github.com/hexops/autogold v1.3.0 h1:IEtGNPxBeBu8RMn8eKWh/Ll9dVNgSnJ7bp/qHgMQ14o=
 github.com/hexops/autogold v1.3.0/go.mod h1:d4hwi2rid66Sag+BVuHgwakW/EmaFr8vdTSbWDbrDRI=

--- a/internal/scaling/markdown.go
+++ b/internal/scaling/markdown.go
@@ -18,6 +18,7 @@ func (e *Estimate) MarkdownExport() []byte {
 	if e.ContactSupport {
 		fmt.Fprintf(&buf, "**Estimation is currently not available for your instance size. Please [contact support](mailto:support@sourcegraph.com) for further assists.**\n")
 	} else {
+		fmt.Fprintf(&buf, "* **Instance Size:** %v\n", e.InstanceSize)
 		fmt.Fprintf(&buf, "* **Estimated vCPUs:** %v\n", e.TotalCPU)
 		fmt.Fprintf(&buf, "* **Estimated Memory:** %vg\n", e.TotalMemoryGB)
 		fmt.Fprintf(&buf, "* **Estimated Minimum Volume Size:** %vg\n", e.TotalStorageSize)

--- a/internal/scaling/markdown.go
+++ b/internal/scaling/markdown.go
@@ -22,7 +22,7 @@ func (e *Estimate) MarkdownExport() []byte {
 		fmt.Fprintf(&buf, "* **Estimated vCPUs:** %v\n", e.TotalCPU)
 		fmt.Fprintf(&buf, "* **Estimated Memory:** %vg\n", e.TotalMemoryGB)
 		fmt.Fprintf(&buf, "* **Estimated Minimum Volume Size:** %vg\n", e.TotalStorageSize)
-		fmt.Fprintf(&buf, "* **Recommend Deployment Type:** %v\n", e.RecommendedDeploymentType)
+		fmt.Fprintf(&buf, "* **Recommend Deployment Type:** [%v](https://docs.sourcegraph.com/admin/deploy#deployment-types)\n", e.RecommendedDeploymentType)
 
 		fmt.Fprintf(&buf, "\n<small>**Note:** The estimated values include default values for services that are not listed in the estimator, like otel-collector and repo-updater for example. The default values for the non-displaying services should work well with instances of all sizes.</small>\n")
 		if e.EngagedUsers < 650/2 && e.AverageRepositories < 1500/2 {

--- a/internal/scaling/references.go
+++ b/internal/scaling/references.go
@@ -52,10 +52,10 @@ var References = []ServiceScale{
 		},
 	},
 	{
-		ServiceName:       "minio",
-		ServiceLabel:      "minio",
-		DockerServiceName: "minio",
-		PodName:           "minio",
+		ServiceName:       "blobstore",
+		ServiceLabel:      "blobstore",
+		DockerServiceName: "blobstore",
+		PodName:           "blobstore",
 		ScalingFactor:     ByLargestIndexSize,
 		ReferencePoints: []Service{
 			{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: 1}, Limits: Resource{CPU: 1, MEM: 1}}, Storage: 1000, Value: LargestIndexSizeRange.Max}, // calculation
@@ -405,7 +405,7 @@ var defaults = map[string]map[string]Service{
 		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: .5, MEM: 6}, Limits: Resource{CPU: 2, MEM: 6}}, Storage: 200},
 		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 4, MEM: 8}}, Storage: 200},
 	},
-	"minio": {
+	"blobstore": {
 		"kubernetes":     Service{Replicas: 1, Resources: Resources{Requests: Resource{CPU: 1, MEM: .5}, Limits: Resource{CPU: 1, MEM: .5}}, Storage: 100},
 		"docker-compose": Service{Replicas: 1, Resources: Resources{Limits: Resource{CPU: 1, MEM: 1}}, Storage: 128},
 	},

--- a/internal/scaling/testdata/TestEstimate/default.golden
+++ b/internal/scaling/testdata/TestEstimate/default.golden
@@ -1,9 +1,10 @@
 `### Estimate summary
 
+* **Instance Size:** XS
 * **Estimated vCPUs:** 8
 * **Estimated Memory:** 32g
 * **Estimated Minimum Volume Size:** 1316g
-* **Recommend Deployment Type:** Docker Compose
+* **Recommend Deployment Type:** Sourcegraph Machine Images
 
 <small>**Note:** The estimated values include default values for services that are not listed in the estimator, like otel-collector and repo-updater for example. The default values for the non-displaying services should work well with instances of all sizes.</small>
 * <details><summary>**IMPORTANT:** Cost-saving option to reduce resource consumption is available</summary><br><blockquote>
@@ -20,13 +21,13 @@
 
 | Service | Replica | CPU requests | CPU limits | MEM requests | MEM limits  | Storage |
 |-------|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|
+| **blobstore** | 1 | - | 1 | - | 0.5g | 1Gꜝ |
 | **codeinsights-db** | 1 | - | 4 | - | 4g | 200Gꜝ |
 | **codeintel-db** | 1 | - | 4 | - | 4g | 200Gꜝ |
 | **sourcegraph-frontend-0** | 1 | - | 2 | - | 4g | - |
 | **gitserver-0** | 1 | - | 4 | - | 4g | 39Gꜝ |
 | **zoekt-indexserver-0** | 1 | - | 8 | - | 8g | 18Gꜝ |
 | **zoekt-webserver-0** | 1 | - | 2 | - | 4g | - |
-| **minio** | 1 | - | 1 | - | 0.5g | 1Gꜝ |
 | **pgsql** | 1 | - | 4 | - | 4g | 200Gꜝ |
 | **precise-code-intel-worker** | 1 | - | 2 | - | 4g | - |
 | **prometheus** | 1 | - | 2 | - | 6g | 200Gꜝ |

--- a/internal/scaling/testdata/TestEstimate/default.golden
+++ b/internal/scaling/testdata/TestEstimate/default.golden
@@ -4,7 +4,7 @@
 * **Estimated vCPUs:** 8
 * **Estimated Memory:** 32g
 * **Estimated Minimum Volume Size:** 1316g
-* **Recommend Deployment Type:** Sourcegraph Machine Images
+* **Recommend Deployment Type:** [Sourcegraph Machine Images](https://docs.sourcegraph.com/admin/deploy#deployment-types)
 
 <small>**Note:** The estimated values include default values for services that are not listed in the estimator, like otel-collector and repo-updater for example. The default values for the non-displaying services should work well with instances of all sizes.</small>
 * <details><summary>**IMPORTANT:** Cost-saving option to reduce resource consumption is available</summary><br><blockquote>

--- a/internal/scaling/testdata/TestEstimate/monorepo.golden
+++ b/internal/scaling/testdata/TestEstimate/monorepo.golden
@@ -4,7 +4,7 @@
 * **Estimated vCPUs:** 192
 * **Estimated Memory:** 32g
 * **Estimated Minimum Volume Size:** 1316g
-* **Recommend Deployment Type:** Kubernetes with auto-scaling enabled
+* **Recommend Deployment Type:** [Kubernetes with auto-scaling enabled](https://docs.sourcegraph.com/admin/deploy#deployment-types)
 
 <small>**Note:** The estimated values include default values for services that are not listed in the estimator, like otel-collector and repo-updater for example. The default values for the non-displaying services should work well with instances of all sizes.</small>
 

--- a/internal/scaling/testdata/TestEstimate/monorepo.golden
+++ b/internal/scaling/testdata/TestEstimate/monorepo.golden
@@ -1,5 +1,6 @@
 `### Estimate summary
 
+* **Instance Size:** XS
 * **Estimated vCPUs:** 192
 * **Estimated Memory:** 32g
 * **Estimated Minimum Volume Size:** 1316g
@@ -10,13 +11,13 @@
 
 | Service | Replica | CPU requests | CPU limits | MEM requests | MEM limits  | Storage |
 |-------|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|
+| **blobstore** | 1 | - | 1 | - | 0.5g | 1Gꜝ |
 | **codeinsights-db** | 1 | - | 4 | - | 4g | 200Gꜝ |
 | **codeintel-db** | 1 | - | 4 | - | 4g | 200Gꜝ |
 | **sourcegraph-frontend-0** | 1 | - | 24 | - | 108g | - |
 | **gitserver-0** | 1 | - | 4 | - | 4g | 39Gꜝ |
 | **zoekt-indexserver-0** | 1 | - | 8 | - | 8g | 18Gꜝ |
 | **zoekt-webserver-0** | 1 | - | 2 | - | 4g | - |
-| **minio** | 1 | - | 1 | - | 0.5g | 1Gꜝ |
 | **pgsql** | 1 | - | 4 | - | 4g | 200Gꜝ |
 | **precise-code-intel-worker** | 1 | - | 2 | - | 4g | - |
 | **prometheus** | 1 | - | 2 | - | 6g | 200Gꜝ |

--- a/scaling.go
+++ b/scaling.go
@@ -46,6 +46,7 @@ func (p *MainView) numberInput(postLabel string, handler func(e *vecty.Event), v
 	errorLabel := ""
 	if float64(value) > rnge.Max {
 		errorLabel = fmt.Sprint("- value must be lower than ", int(rnge.Max))
+		value = 0
 	}
 	return elem.Label(
 		vecty.Markup(vecty.Style("margin-top", "10px")),
@@ -59,7 +60,6 @@ func (p *MainView) numberInput(postLabel string, handler func(e *vecty.Event), v
 				vecty.Property("min", rnge.Min),
 				vecty.Property("max", rnge.Max),
 				vecty.MarkupIf(float64(value) > rnge.Max, vecty.Class("errorInput")),
-				vecty.MarkupIf(postLabel == "GB - size of the largest LSIF index file" && value == 0, vecty.Property("disabled", true)),
 				vecty.MarkupIf(postLabel == "GB - size of the largest LSIF index file" && value > 0, vecty.Property("disabled", false)),
 			),
 		),

--- a/scaling.go
+++ b/scaling.go
@@ -148,26 +148,18 @@ func (p *MainView) inputs() vecty.ComponentOrHTML {
 				p.largestRepoSize, _ = strconv.Atoi(e.Value.Get("target").Get("value").String())
 				vecty.Rerender(p)
 			}, p.largestRepoSize, scaling.LargestRepoSizeRange, 1),
-			p.radioInput("Code Insights: ", []string{"Enable", "Disable"}, func(e *vecty.Event) {
-				p.codeinsightEabled = e.Value.Get("target").Get("value").String()
-				vecty.Rerender(p)
-			}),
-			p.radioInput("Precise Code Intelligence: ", []string{"Enable", "Disable"}, func(e *vecty.Event) {
-				if e.Value.Get("target").Get("value").String() == "Enable" {
-					p.largestIndexSize = 1
-				} else {
-					p.largestIndexSize = 0
-				}
-				vecty.Rerender(p)
-			}),
 			p.numberInput("GB - size of the largest LSIF index file", func(e *vecty.Event) {
 				p.largestIndexSize, _ = strconv.Atoi(e.Value.Get("target").Get("value").String())
 				vecty.Rerender(p)
 			}, p.largestIndexSize, scaling.LargestIndexSizeRange, 1),
 			elem.Div(
 				vecty.Markup(vecty.Style("margin-top", "5px"), vecty.Style("font-size", "small")),
-				vecty.Text("The minimum value is 1 when Precise Code Intelligence is enabled."),
+				vecty.Text("Note: Set the value above to 0 to disable Precise Code Intelligence."),
 			),
+			p.radioInput("Code Insights: ", []string{"Enable", "Disable"}, func(e *vecty.Event) {
+				p.codeinsightEabled = e.Value.Get("target").Get("value").String()
+				vecty.Rerender(p)
+			}),
 		),
 	}
 }
@@ -188,7 +180,6 @@ func (p *MainView) Render() vecty.ComponentOrHTML {
 
 	markdownContent := estimate.MarkdownExport()
 	helmContent := estimate.HelmExport()
-	dockerContent := estimate.DockerExport()
 
 	return elem.Form(
 		vecty.Markup(vecty.Class("estimator")),
@@ -217,24 +208,6 @@ func (p *MainView) Render() vecty.ComponentOrHTML {
 						vecty.Property("download", "override.yaml"),
 					),
 					vecty.Text("override.yaml"),
-				),
-			),
-		),
-		elem.Details(
-			elem.Summary(vecty.Text("Export as Docker Compose Override File")),
-			elem.Break(),
-			elem.TextArea(
-				vecty.Markup(vecty.Class("copy-as-markdown")),
-				vecty.Text(dockerContent),
-			),
-			elem.Paragraph(
-				elem.Strong(vecty.Text("Click to Download: ")),
-				elem.Anchor(
-					vecty.Markup(
-						vecty.Markup(prop.Href("data:text/csv;charset=utf-8,"+dockerContent)),
-						vecty.Property("download", "docker-compose.override.yaml"),
-					),
-					vecty.Text("docker-compose.override.yaml"),
 				),
 			),
 		),


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/45962

Changes included in this PR:
- Replace `minio` with `blobstore`
- Replace `Docker Compose` with `AMI` in `Recommend Deployment Type`
- Add `Instance Size` to output
- Remove override file export for `Docker Compose`, we should create override file and link in the docs for each instance size instead

![image](https://user-images.githubusercontent.com/68532117/216226483-11fbab07-07ab-4a4b-b42b-de41b9bd2a4c.png)
