### PR TITLE
Update ubuntu in Github Actions to latest LTS (24.04)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@
 jobs:
   checkPipeline:
     name: render-CI-pipeline
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: 'actions/checkout@v2'
       - name: Install asdf
@@ -15,7 +15,7 @@ jobs:
         run: ci/check-rendered-pipeline-up-to-date.sh
   dhallCheck:
     name: dhall-check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: 'actions/checkout@v2'
       - name: Install asdf
@@ -28,7 +28,7 @@ jobs:
         run: just check-dhall
   dhallFormat:
     name: dhall-format
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: 'actions/checkout@v2'
       - name: Install asdf
@@ -43,7 +43,7 @@ jobs:
         run: just format-dhall
   dhallLint:
     name: dhall-lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: 'actions/checkout@v2'
       - name: Install asdf
@@ -58,7 +58,7 @@ jobs:
         run: just lint-dhall
   golangciLint:
     name: golangci-lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: 'actions/checkout@v2'
       - name: Install asdf
@@ -74,7 +74,7 @@ jobs:
           working-directory: '.'
   prettier:
     name: Prettier formatting
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: 'actions/checkout@v2'
       - name: Install asdf
@@ -87,7 +87,7 @@ jobs:
         run: ci/check-prettier.sh
   shellcheck:
     name: shellcheck
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: 'actions/checkout@v2'
       - name: Install asdf
@@ -100,7 +100,7 @@ jobs:
         run: just shellcheck
   shfmt:
     name: shfmt
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: 'actions/checkout@v2'
       - name: Install asdf
@@ -113,7 +113,7 @@ jobs:
         run: ci/check-shfmt.sh
   wasmBuild:
     name: Build WASM
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: 'actions/checkout@v2'
       - name: Install asdf


### PR DESCRIPTION
Test Plan: CI

[_Created by Sourcegraph batch change `keegan/update-old-ubuntu-on-github-actions`._](https://sourcegraph.sourcegraph.com/users/keegan/batch-changes/update-old-ubuntu-on-github-actions)